### PR TITLE
Fix load_urdf for urdf files with defined transmissions etc.

### DIFF
--- a/pytransform3d/test/test_urdf.py
+++ b/pytransform3d/test/test_urdf.py
@@ -67,6 +67,16 @@ COMPI_URDF = """
       <parent link="link6"/>
       <child link="tcp"/>
     </joint>
+    
+    <transmission name="joint1_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="joint1">
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
+      </joint>
+      <actuator name="joint1_motor">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
   </robot>
 """
 

--- a/pytransform3d/urdf.py
+++ b/pytransform3d/urdf.py
@@ -117,9 +117,10 @@ class UrdfTransformManager(TransformManager):
 
         robot_name = robot["name"]
 
-        links = [self._parse_link(link) for link in robot.findAll("link")]
+        links = [self._parse_link(link)
+                 for link in robot.findAll("link", recursive=False)]
         joints = [self._parse_joint(joint, links)
-                  for joint in robot.findAll("joint")]
+                  for joint in robot.findAll("joint", recursive=False)]
 
         self.add_transform(links[0], robot_name, np.eye(4))
         for joint in joints:


### PR DESCRIPTION
Let load_urdf only search for joint and links at top level by setting recursive search in robot.findAll to False.

It solves the issue **UrdfException: Joint type is missing in joint 'joint1'** when e.g. transmissions for certain joints are defined in the URDF file:

  <joint name="the_joint_name" type="revolute">
    <parent link="parent_link"/>
    <child link="child_link"/>
    <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
    <axis xyz="0 0 1"/>
    <limit effort="1.0" lower="-1.0" upper="1.0" velocity="1.0"/>
    <dynamics damping="0.0" friction="0.0"/>
  </joint>
<transmission name="transmission_name">
    <type>the_type</type>
    <joint name="the_joint_name">
      <hardwareInterface>the_hardware_interface
    </joint>
    <actuator name="the_actuator_name">
      <mechanicalReduction>int</mechanicalReduction>
    </actuator>
  </transmission>

In this case, the load_urdf would try to load the attributes for the "the_joint_name" defined within the transmission part (which are only "hardwareInterface") and throws an error, even though "the_joint_name" has been properly loaded earlier from the joint definition commands at the top level of the urdf file.

The test_urdf.py is extended with a transmission for joint1. 