### PR TITLE
[MRG] Make transform manager faster

### DIFF
--- a/pytransform3d/test/test_transform_manager.py
+++ b/pytransform3d/test/test_transform_manager.py
@@ -261,3 +261,11 @@ def test_deactivate_transform_manager_precision_error():
             assert_equal(len(w), n_expected_warnings)
     finally:
         warnings.filterwarnings("default", category=UserWarning)
+
+
+def test_deactivate_checks():
+    tm = TransformManager(check=False)
+    tm.add_transform("A", "B", np.zeros((4, 4)))
+    tm.add_transform("B", "C", np.zeros((4, 4)))
+    A2B = tm.get_transform("A", "C")
+    assert_array_almost_equal(A2B, np.zeros((4, 4)))

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -2,6 +2,7 @@ import warnings
 import platform
 import numpy as np
 from pytransform3d.transformations import (random_transform, transform_from,
+                                           translate_transform, rotate_transform,
                                            invert_transform, vector_to_point,
                                            vectors_to_points, vector_to_direction,
                                            vectors_to_directions,
@@ -39,6 +40,20 @@ def test_check_transform():
     A2B = random_transform(random_state)
     A2B2 = check_transform(A2B)
     assert_array_almost_equal(A2B, A2B2)
+
+
+def test_translate_transform_with_check():
+    A2B_broken = np.zeros((4, 4))
+    assert_raises_regexp(
+        ValueError, "rotation matrix", translate_transform,
+        A2B_broken, np.zeros(3))
+
+
+def test_rotate_transform_with_check():
+    A2B_broken = np.zeros((4, 4))
+    assert_raises_regexp(
+        ValueError, "rotation matrix", rotate_transform,
+        A2B_broken, np.eye(3))
 
 
 def test_check_pq():

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -72,6 +72,17 @@ def test_invert_transform():
         assert_array_almost_equal(A2B, A2B2)
 
 
+def test_invert_transform_without_check():
+    """Test inversion of transformations."""
+    random_state = np.random.RandomState(0)
+    for _ in range(5):
+        A2B = random_state.randn(4, 4)
+        A2B = A2B + A2B.T
+        B2A = invert_transform(A2B, check=False)
+        A2B2 = np.linalg.inv(B2A)
+        assert_array_almost_equal(A2B, A2B2)
+
+
 def test_vector_to_point():
     """Test conversion from vector to homogenous coordinates."""
     v = np.array([1, 2, 3])

--- a/pytransform3d/transform_manager.py
+++ b/pytransform3d/transform_manager.py
@@ -44,8 +44,8 @@ class TransformManager(object):
         warning.
 
     check : bool, optional (default: True)
-        Check if transformation matrices are valid. This might significantly
-        slow down some operations.
+        Check if transformation matrices are valid and requested nodes exist,
+        which might significantly slow down some operations.
     """
     def __init__(self, strict_check=True, check=True):
         self.strict_check = strict_check
@@ -134,10 +134,11 @@ class TransformManager(object):
             Homogeneous matrix that represents the transform from 'from_frame'
             to 'to_frame'
         """
-        if from_frame not in self.nodes:
-            raise KeyError("Unknown frame '%s'" % from_frame)
-        if to_frame not in self.nodes:
-            raise KeyError("Unknown frame '%s'" % to_frame)
+        if self.check:
+            if from_frame not in self.nodes:
+                raise KeyError("Unknown frame '%s'" % from_frame)
+            if to_frame not in self.nodes:
+                raise KeyError("Unknown frame '%s'" % to_frame)
 
         if (from_frame, to_frame) in self.transforms:
             return self.transforms[(from_frame, to_frame)]

--- a/pytransform3d/transform_manager.py
+++ b/pytransform3d/transform_manager.py
@@ -58,6 +58,7 @@ class TransformManager(object):
         self.connections = sp.csr_matrix((0, 0))
         self.dist = None
         self.predecessors = None
+        self._cached_shortest_paths = {}
 
     def add_transform(self, from_frame, to_frame, A2B):
         """Register a transform.
@@ -108,6 +109,7 @@ class TransformManager(object):
         self.dist, self.predecessors = csgraph.shortest_path(
             self.connections, unweighted=True, directed=False, method="D",
             return_predecessors=True)
+        self._cached_shortest_paths.clear()
 
     def has_frame(self, frame):
         """Check if frame has been registered.
@@ -165,11 +167,15 @@ class TransformManager(object):
             return self._path_transform(path)
 
     def _shortest_path(self, i, j):
+        if (i, j) in self._cached_shortest_paths:
+            return self._cached_shortest_paths[(i, j)]
+
         path = []
         k = i
         while k != -9999:
             path.append(self.nodes[k])
             k = self.predecessors[j, k]
+        self._cached_shortest_paths[(i, j)] = path
         return path
 
     def _path_transform(self, path):

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -112,7 +112,7 @@ def random_transform(random_state=np.random.RandomState(0)):
     return transform_from(R=R, p=p)
 
 
-def invert_transform(A2B, strict_check=True):
+def invert_transform(A2B, strict_check=True, check=True):
     """Invert transform.
 
     Parameters
@@ -125,13 +125,18 @@ def invert_transform(A2B, strict_check=True):
         close enough to a real transformation matrix. Otherwise we print a
         warning.
 
+    check : bool, optional (default: True)
+        Check if transformation matrix is valid
+
     Returns
     -------
     B2A : array-like, shape (4, 4)
         Transform from frame B to frame A
     """
-    A2B = check_transform(A2B, strict_check=strict_check)
-    # NOTE there is a faster version:
+    if check:
+        A2B = check_transform(A2B, strict_check=strict_check)
+    # NOTE there is a faster version, but it is not faster than matrix
+    # inversion with numpy:
     # ( R t )^-1   ( R^T -R^T*t )
     # ( 0 1 )    = ( 0    1     )
     return np.linalg.inv(A2B)
@@ -272,7 +277,7 @@ def vectors_to_directions(V):
     return np.hstack((V, np.zeros((len(V), 1))))
 
 
-def concat(A2B, B2C, strict_check=True):
+def concat(A2B, B2C, strict_check=True, check=True):
     """Concatenate transforms.
 
     Parameters
@@ -288,13 +293,17 @@ def concat(A2B, B2C, strict_check=True):
         close enough to a real transformation matrix. Otherwise we print a
         warning.
 
+    check : bool, optional (default: True)
+        Check if transformation matrices are valid
+
     Returns
     -------
     A2C : array-like, shape (4, 4)
         Transform from frame A to frame C
     """
-    A2B = check_transform(A2B, strict_check=strict_check)
-    B2C = check_transform(B2C, strict_check=strict_check)
+    if check:
+        A2B = check_transform(A2B, strict_check=strict_check)
+        B2C = check_transform(B2C, strict_check=strict_check)
     return B2C.dot(A2B)
 
 

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -85,8 +85,10 @@ def transform_from(R, p, strict_check=True):
     A2B : array-like, shape (4, 4)
         Transform from frame A to frame B
     """
-    A2B = rotate_transform(np.eye(4), R, strict_check=True)
-    A2B = translate_transform(A2B, p, strict_check=True)
+    A2B = rotate_transform(
+        np.eye(4), R, strict_check=strict_check, check=False)
+    A2B = translate_transform(
+        A2B, p, strict_check=strict_check, check=False)
     return A2B
 
 
@@ -142,7 +144,7 @@ def invert_transform(A2B, strict_check=True, check=True):
     return np.linalg.inv(A2B)
 
 
-def translate_transform(A2B, p, strict_check=True):
+def translate_transform(A2B, p, strict_check=True, check=True):
     """Sets the translation of a transform.
 
     Parameters
@@ -158,19 +160,23 @@ def translate_transform(A2B, p, strict_check=True):
         close enough to a real transformation matrix. Otherwise we print a
         warning.
 
+    check : bool, optional (default: True)
+        Check if transformation matrix is valid
+
     Returns
     -------
     A2B : array-like, shape (4, 4)
         Transform from frame A to frame B
     """
-    A2B = check_transform(A2B, strict_check=strict_check)
+    if check:
+        A2B = check_transform(A2B, strict_check=strict_check)
     out = A2B.copy()
     l = len(p)
     out[:l, -1] = p
     return out
 
 
-def rotate_transform(A2B, R, strict_check=True):
+def rotate_transform(A2B, R, strict_check=True, check=True):
     """Sets the rotation of a transform.
 
     Parameters
@@ -186,12 +192,16 @@ def rotate_transform(A2B, R, strict_check=True):
         close enough to a real transformation matrix. Otherwise we print a
         warning.
 
+    check : bool, optional (default: True)
+        Check if transformation matrix is valid
+
     Returns
     -------
     A2B : array-like, shape (4, 4)
         Transform from frame A to frame B
     """
-    A2B = check_transform(A2B, strict_check=strict_check)
+    if check:
+        A2B = check_transform(A2B, strict_check=strict_check)
     out = A2B.copy()
     out[:3, :3] = R
     return out

--- a/pytransform3d/urdf.py
+++ b/pytransform3d/urdf.py
@@ -23,9 +23,20 @@ class UrdfTransformManager(TransformManager):
     .. note::
 
         Joint angles must be given in radians.
+
+    Parameters
+    ----------
+    strict_check : bool, optional (default: True)
+        Raise a ValueError if the transformation matrix is not numerically
+        close enough to a real transformation matrix. Otherwise we print a
+        warning.
+
+    check : bool, optional (default: True)
+        Check if transformation matrices are valid. This might significantly
+        slow down some operations.
     """
-    def __init__(self):
-        super(UrdfTransformManager, self).__init__()
+    def __init__(self, strict_check=True, check=True):
+        super(UrdfTransformManager, self).__init__(strict_check, check)
         self._joints = {}
         self.collision_objects = []
         self.visuals = []

--- a/pytransform3d/urdf.py
+++ b/pytransform3d/urdf.py
@@ -93,12 +93,16 @@ class UrdfTransformManager(TransformManager):
         value = np.clip(value, limits[0], limits[1])
         if joint_type == "revolute":
             joint_rotation = matrix_from_axis_angle(np.hstack((axis, [value])))
-            joint2A = transform_from(joint_rotation, np.zeros(3))
+            joint2A = transform_from(joint_rotation, np.zeros(3),
+                                     strict_check=self.strict_check)
         else:
             assert joint_type == "prismatic"
             joint_offset = value * norm_vector(axis)
-            joint2A = transform_from(np.eye(3), joint_offset)
-        self.add_transform(from_frame, to_frame, concat(joint2A, child2parent))
+            joint2A = transform_from(np.eye(3), joint_offset,
+                                     strict_check=self.strict_check)
+        self.add_transform(from_frame, to_frame, concat(
+            joint2A, child2parent, strict_check=self.strict_check,
+            check=self.check))
 
     def get_joint_limits(self, joint_name):
         """Get limits of a joint.
@@ -273,8 +277,10 @@ class UrdfTransformManager(TransformManager):
                 # For more details on how the URDF parser handles the conversion
                 # from Euler angles, see this blog post:
                 # https://orbitalstation.wordpress.com/tag/quaternion/
-                rotation = active_matrix_from_extrinsic_roll_pitch_yaw(roll_pitch_yaw)
-        return transform_from(rotation, translation)
+                rotation = active_matrix_from_extrinsic_roll_pitch_yaw(
+                    roll_pitch_yaw)
+        return transform_from(
+            rotation, translation, strict_check=self.strict_check)
 
     def _parse_limits(self, joint):
         """Parse joint limits."""

--- a/pytransform3d/urdf.py
+++ b/pytransform3d/urdf.py
@@ -32,8 +32,8 @@ class UrdfTransformManager(TransformManager):
         warning.
 
     check : bool, optional (default: True)
-        Check if transformation matrices are valid. This might significantly
-        slow down some operations.
+        Check if transformation matrices are valid and requested nodes exist,
+        which might significantly slow down some operations.
     """
     def __init__(self, strict_check=True, check=True):
         super(UrdfTransformManager, self).__init__(strict_check, check)

--- a/pytransform3d/visualizer.py
+++ b/pytransform3d/visualizer.py
@@ -584,7 +584,8 @@ try:
                     "This viewer does not support text. Frame label "
                     "will be ignored.")
 
-            self.frame.transform(pt.concat(pt.invert_transform(previous_A2B), self.A2B))
+            self.frame.transform(pt.invert_transform(previous_A2B, check=False))
+            self.frame.transform(self.A2B)
 
         @property
         def geometries(self):
@@ -701,7 +702,7 @@ try:
                 previous_A2B = np.eye(4)
             self.A2B = A2B
 
-            self.sphere.transform(pt.invert_transform(previous_A2B))
+            self.sphere.transform(pt.invert_transform(previous_A2B, check=False))
             self.sphere.transform(self.A2B)
 
         @property
@@ -757,7 +758,7 @@ try:
                 previous_A2B = np.eye(4)
             self.A2B = A2B
 
-            self.box.transform(pt.invert_transform(previous_A2B))
+            self.box.transform(pt.invert_transform(previous_A2B, check=False))
             self.box.transform(self.A2B)
 
         @property
@@ -819,7 +820,7 @@ try:
                 previous_A2B = np.eye(4)
             self.A2B = A2B
 
-            self.cylinder.transform(pt.invert_transform(previous_A2B))
+            self.cylinder.transform(pt.invert_transform(previous_A2B, check=False))
             self.cylinder.transform(self.A2B)
 
         @property
@@ -876,7 +877,7 @@ try:
                 previous_A2B = np.eye(4)
             self.A2B = A2B
 
-            self.mesh.transform(pt.invert_transform(previous_A2B))
+            self.mesh.transform(pt.invert_transform(previous_A2B, check=False))
             self.mesh.transform(self.A2B)
 
         @property


### PR DESCRIPTION
Fixes #71, #31 

* Adds option to turn checks in TransformManager off to make it faster

TODO
`   ncalls  tottime  percall  cumtime  percall filename:lineno(function)`
- [x] `     2865   10.548    0.004   11.440    0.004 {scipy.sparse.csgraph._shortest_path.shortest_path}`
- [x] `    21577    0.425    0.000    0.441    0.000 transform_manager.py:159(_shortest_path)`
- [x] `    21577    0.138    0.000    0.768    0.000 transform_manager.py:167(_path_transform)`

Notes
* Using a set as proposed in #31 does not give us speed advantage in the benchmarks that I did.
* Caching inverted transformations results in 20% increased speed, but this is not worth implementing a complicated caching procedure.

Examples

Visualization of ATLAS from [this repository](https://github.com/team-vigir/vigir_atlas_common)
![atlas](https://user-images.githubusercontent.com/869592/101295505-4e5faf00-381e-11eb-85ce-cf35f455c326.gif)

Visualization of Nao from [bullet](https://github.com/bulletphysics/bullet3)
![nao](https://user-images.githubusercontent.com/869592/101495642-0e591300-3969-11eb-80ea-7c71c4df5576.gif)
