### PR TITLE
[MRG] Screws / exponential coordinates of 3D transformations

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -48,6 +48,7 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf source/_apidoc
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/source/_static/rotations.svg
+++ b/doc/source/_static/rotations.svg
@@ -13,7 +13,7 @@
    height="400"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
    sodipodi:docname="rotations.svg">
   <defs
      id="defs4">
@@ -39,15 +39,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4142136"
-     inkscape:cx="294.52522"
+     inkscape:cx="232.21223"
      inkscape:cy="209.39227"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1366"
-     inkscape:window-height="748"
-     inkscape:window-x="1277"
-     inkscape:window-y="-3"
+     inkscape:window-width="1920"
+     inkscape:window-height="1015"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
@@ -57,7 +57,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -75,28 +75,26 @@
        y="954.27539" />
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="268.65686"
        y="995.68451"
-       id="text2985"
-       sodipodi:linespacing="125%"><tspan
+       id="text2985"><tspan
          sodipodi:role="line"
          id="tspan2987"
          x="268.65686"
          y="995.68451"
-         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Serif;-inkscape-font-specification:Serif Italic">R</tspan></text>
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:serif;-inkscape-font-specification:'Serif Italic'">R</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="227.15686"
        y="1016.1846"
-       id="text2989"
-       sodipodi:linespacing="125%"><tspan
+       id="text2989"><tspan
          sodipodi:role="line"
          id="tspan2991"
          x="227.15686"
          y="1016.1846"
-         style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Times New Roman;-inkscape-font-specification:Times New Roman">rotation matrix</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">rotation matrix</tspan></text>
     <rect
        style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none"
        id="rect3142"
@@ -106,28 +104,26 @@
        y="810.73267" />
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="66.476562"
        y="857.44226"
-       id="text2985-8"
-       sodipodi:linespacing="125%"><tspan
+       id="text2985-8"><tspan
          sodipodi:role="line"
          id="tspan2987-5"
          x="66.476562"
          y="857.44226"
-         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Serif;-inkscape-font-specification:Serif Italic">θê</tspan></text>
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:serif;-inkscape-font-specification:'Serif Italic'">θω</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="48.371094"
        y="878.66882"
-       id="text2989-2"
-       sodipodi:linespacing="125%"><tspan
+       id="text2989-2"><tspan
          sodipodi:role="line"
          id="tspan2991-0"
          x="48.371094"
          y="878.66882"
-         style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Times New Roman;-inkscape-font-specification:Times New Roman">axis-angle</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">axis-angle</tspan></text>
     <rect
        style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none"
        id="rect3144"
@@ -137,40 +133,37 @@
        y="773.96313" />
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
-       x="430.80054"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="444.80054"
        y="850.22333"
-       id="text2985-8-4"
-       sodipodi:linespacing="125%"><tspan
+       id="text2985-8-4"><tspan
          sodipodi:role="line"
          id="tspan2987-5-7"
-         x="430.80054"
+         x="444.80054"
          y="850.22333"
-         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Serif;-inkscape-font-specification:Serif Italic">(α,β,γ)</tspan></text>
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:serif;-inkscape-font-specification:'Serif Italic'">(α,β,γ)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="447.42944"
        y="880.29559"
-       id="text2989-2-4"
-       sodipodi:linespacing="125%"><tspan
+       id="text2989-2-4"><tspan
          sodipodi:role="line"
          id="tspan2991-0-5"
          x="447.42944"
          y="880.29559"
-         style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Times New Roman;-inkscape-font-specification:Times New Roman">Euler angles</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">Euler angles</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
-       x="430.69116"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="444.69116"
        y="810.10419"
-       id="text2985-8-4-3"
-       sodipodi:linespacing="125%"><tspan
+       id="text2985-8-4-3"><tspan
          sodipodi:role="line"
          id="tspan2987-5-7-9"
-         x="430.69116"
+         x="444.69116"
          y="810.10419"
-         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Serif;-inkscape-font-specification:Serif Italic">(γ,β,α)</tspan></text>
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:serif;-inkscape-font-specification:'Serif Italic'">(γ,β,α)</tspan></text>
     <rect
        style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none"
        id="rect3146"
@@ -180,28 +173,26 @@
        y="736.48651" />
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="269.47803"
        y="775.39703"
-       id="text2985-4"
-       sodipodi:linespacing="125%"><tspan
+       id="text2985-4"><tspan
          sodipodi:role="line"
          id="tspan2987-8"
          x="269.47803"
          y="775.39703"
-         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Serif;-inkscape-font-specification:Serif Italic">q</tspan></text>
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:serif;-inkscape-font-specification:'Serif Italic'">q</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="243.87256"
        y="800.6236"
-       id="text2989-9"
-       sodipodi:linespacing="125%"><tspan
+       id="text2989-9"><tspan
          sodipodi:role="line"
          id="tspan2991-9"
          x="243.87256"
          y="800.6236"
-         style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Times New Roman;-inkscape-font-specification:Times New Roman">quaternion</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">quaternion</tspan></text>
     <path
        style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker-end:url(#Arrow1Lend)"
        d="m 304.68333,827.70323 0,115.25841"
@@ -244,53 +235,60 @@
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="728.31073"
        y="577.03131"
        id="text6016"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.72024426,0.69372056,-0.69372056,0.72024426,0,0)"><tspan
+       transform="rotate(43.92535)"><tspan
          sodipodi:role="line"
          id="tspan6018"
          x="728.31073"
          y="577.03131"
-         style="font-size:14px;font-family:Times New Roman;-inkscape-font-specification:Times New Roman">exponential map</tspan></text>
+         style="font-size:14px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">exponential map</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="730.76025"
        y="503.71512"
        id="text6016-5"
-       sodipodi:linespacing="125%"
-       transform="matrix(0.72024426,0.69372056,-0.69372056,0.72024426,0,0)"><tspan
+       transform="rotate(43.92535)"><tspan
          sodipodi:role="line"
          id="tspan6018-1"
          x="730.76025"
          y="503.71512"
-         style="font-size:14px;font-family:Times New Roman;-inkscape-font-specification:Times New Roman">logarithmic map</tspan></text>
+         style="font-size:14px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">logarithmic map</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="7.1923866"
        y="703.03064"
-       id="text6041"
-       sodipodi:linespacing="125%"><tspan
+       id="text6041"><tspan
          sodipodi:role="line"
          id="tspan6043"
          x="7.1923866"
          y="703.03064"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Sans;-inkscape-font-specification:Sans Bold">pytransform3d.rotations</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'Sans Bold'">pytransform3d.rotations</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
-       x="268.61435"
-       y="771.42651"
-       id="text2985-4-4"
-       sodipodi:linespacing="125%"><tspan
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="271.44278"
+       y="767.1839"
+       id="text2985-4-4"><tspan
          sodipodi:role="line"
          id="tspan2987-8-1"
-         x="268.61435"
-         y="771.42651"
-         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Serif;-inkscape-font-specification:Serif Italic">^</tspan></text>
+         x="271.44278"
+         y="767.1839"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif">^</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="91.731499"
+       y="849.24847"
+       id="text2985-4-4-2"><tspan
+         sodipodi:role="line"
+         id="tspan2987-8-1-0"
+         x="91.731499"
+         y="849.24847"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif">^</tspan></text>
   </g>
 </svg>

--- a/doc/source/_static/screw_axis.svg
+++ b/doc/source/_static/screw_axis.svg
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="59.623627mm"
+   height="33.905945mm"
+   viewBox="0 0 59.623627 33.905944"
+   version="1.1"
+   id="svg1529"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="screw_axis.svg">
+  <defs
+     id="defs1523">
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4489"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path4487"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2839"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2837"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2206"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2188"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-18-8-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path840-79-4-92"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-3-2-5-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path840-6-02-0-40"
+         style="fill:#00f200;fill-opacity:1;fill-rule:evenodd;stroke:#00f200;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-3-5-3-3-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path840-6-3-7-6-9"
+         style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3704-5-1-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3462-9-0-6"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6"
+     inkscape:cx="196.23325"
+     inkscape:cy="95.301313"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1015"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2158"
+       originx="-92.231449"
+       originy="-235.89047" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1526">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-92.231443,-27.203568)">
+    <path
+       style="fill:none;stroke:#0000ff;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-18-8-0)"
+       d="M 93.498361,54.059679 V 43.476345"
+       id="path817-3-6-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#00f200;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-3-2-5-5)"
+       d="m 93.49836,54.059678 h 10.58333"
+       id="path817-7-6-1-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#ff0000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-3-5-3-3-5)"
+       d="m 93.498362,54.059678 1.322916,6.614583"
+       id="path817-7-5-1-5-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path2152"
+       d="M 93.498359,54.059676 113.77083,43.79375"
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2839)" />
+    <text
+       id="text2156"
+       y="45.994774"
+       x="102.24599"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Bold';stroke-width:0.26458332"
+         y="45.994774"
+         x="102.24599"
+         id="tspan2154"
+         sodipodi:role="line">q</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path2183"
+       d="m 112.7125,56.758333 5.02708,-28.575"
+       style="fill:none;stroke:#000000;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.05833327, 0.26458332;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#Arrow2Lend)" />
+    <text
+       id="text2827"
+       y="30.621279"
+       x="112.82589"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Bold';stroke-width:0.26458332"
+         y="30.621279"
+         x="112.82589"
+         id="tspan2825"
+         sodipodi:role="line">ŝ</tspan></text>
+    <path
+       d="m 115.75759,43.182224 a 0.66145831,0.66145831 0 0 1 -0.6602,0.661457 0.66145831,0.66145831 0 0 1 -0.66271,-0.658934 0.66145831,0.66145831 0 0 1 0.65767,-0.66397 0.66145831,0.66145831 0 0 1 0.66522,0.656402"
+       sodipodi:open="true"
+       sodipodi:end="6.2755582"
+       sodipodi:start="0"
+       sodipodi:ry="0.66145831"
+       sodipodi:rx="0.66145831"
+       sodipodi:cy="43.182224"
+       sodipodi:cx="115.09613"
+       sodipodi:type="arc"
+       id="path2829"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.14999999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4485"
+       d="m 114.93163,40.791482 c -1.25313,-1.124938 0.25226,-2.548012 2.03793,-2.104747"
+       style="fill:none;stroke:#000000;stroke-width:0.13;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path6321"
+       d="m 116.58609,38.171173 0.38347,0.515563 -0.51256,0.349071"
+       style="fill:none;stroke:#000000;stroke-width:0.13;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="121.00628"
+       y="43.561668"
+       id="text6343"><tspan
+         sodipodi:role="line"
+         id="tspan6341"
+         x="121.00628"
+         y="43.561668"
+         style="stroke-width:0.26458332">h = </tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="130.04005"
+       y="40.995743"
+       id="text6347"><tspan
+         sodipodi:role="line"
+         id="tspan6345"
+         x="130.04005"
+         y="40.995743"
+         style="stroke-width:0.26458332">translation</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 130.70416,42.206243 h 20.90209"
+       id="path6349"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93888855px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="132.47736"
+       y="46.300838"
+       id="text6347-3"><tspan
+         sodipodi:role="line"
+         id="tspan6345-6"
+         x="132.47736"
+         y="46.300838"
+         style="stroke-width:0.26458332">rotation</tspan></text>
+  </g>
+</svg>

--- a/doc/source/_static/transformations.svg
+++ b/doc/source/_static/transformations.svg
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="600"
+   height="400"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="transformations.svg">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lend"
+       style="overflow:visible;">
+      <path
+         id="path3927"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt;"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-9"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-9"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.0000001"
+     inkscape:cx="278.52516"
+     inkscape:cy="205.53037"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1015"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-right="0.8">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1029" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-652.36218)">
+    <rect
+       style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1.18933082"
+       id="rect3148"
+       width="193.04015"
+       height="74.246208"
+       x="212.41631"
+       y="954.27539" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="296.65686"
+       y="993.68451"
+       id="text2985"><tspan
+         sodipodi:role="line"
+         id="tspan2987"
+         x="296.65686"
+         y="993.68451"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:Serif;-inkscape-font-specification:Serif">T</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="221.15686"
+       y="1016.1846"
+       id="text2989"><tspan
+         sodipodi:role="line"
+         id="tspan2991"
+         x="221.15686"
+         y="1016.1846"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">transformation matrix</tspan></text>
+    <rect
+       style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none"
+       id="rect3142"
+       width="121.62237"
+       height="86.974136"
+       x="24.325901"
+       y="810.73267" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="38.956879"
+       y="867.35516"
+       id="text2989-2"><tspan
+         sodipodi:role="line"
+         id="tspan2991-0"
+         x="38.956879"
+         y="867.35516"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">exponential</tspan><tspan
+         sodipodi:role="line"
+         x="38.956879"
+         y="892.35516"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'"
+         id="tspan913">coordinates</tspan></text>
+    <rect
+       style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1.1979419"
+       id="rect3146"
+       width="156.2706"
+       height="76.367538"
+       x="425.85132"
+       y="736.48651" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="457.47803"
+       y="775.39703"
+       id="text2985-4"><tspan
+         sodipodi:role="line"
+         id="tspan2987-8"
+         x="457.47803"
+         y="775.39703"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:Serif;-inkscape-font-specification:Serif"><tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Serif;-inkscape-font-specification:'Serif Bold'"
+   id="tspan1076">q</tspan>, <tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Serif;-inkscape-font-specification:'Serif Bold'"
+   id="tspan1078">s</tspan>, h​</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="437.87256"
+       y="804.6236"
+       id="text2989-9"><tspan
+         sodipodi:role="line"
+         id="tspan2991-9"
+         x="437.87256"
+         y="804.6236"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">screw parameters</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="M 225.14423,947.20428 155.14066,881.44335"
+       id="path5280"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="m 130.31223,904.61492 72.832,68.58936"
+       id="path5464"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="M 82.06602,805.6616 216.41631,776.67023"
+       id="path5648"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="m 220.90159,807.19714 -65.76093,16.26345"
+       id="path5832"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="723.98926"
+       y="581.19366"
+       id="text6016"
+       transform="rotate(43.92535)"><tspan
+         sodipodi:role="line"
+         id="tspan6018"
+         x="723.98926"
+         y="581.19366"
+         style="font-size:14px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">exponential map</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="726.43878"
+       y="507.87747"
+       id="text6016-5"
+       transform="rotate(43.92535)"><tspan
+         sodipodi:role="line"
+         id="tspan6018-1"
+         x="726.43878"
+         y="507.87747"
+         style="font-size:14px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">logarithmic map</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="1.1923866"
+       y="703.03064"
+       id="text6041"><tspan
+         sodipodi:role="line"
+         id="tspan6043"
+         x="1.1923866"
+         y="703.03064"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'Sans Bold'">pytransform3d.transformations</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="497.44278"
+       y="767.1839"
+       id="text2985-4-4"><tspan
+         sodipodi:role="line"
+         id="tspan2987-8-1"
+         x="497.44278"
+         y="767.1839"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif">^</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="60.528168"
+       y="845.71411"
+       id="text2985-4-5"><tspan
+         sodipodi:role="line"
+         id="tspan2987-8-6"
+         x="60.528168"
+         y="845.71411"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:Serif;-inkscape-font-specification:Serif"><tspan
+   style="font-style:oblique;font-variant:normal;font-weight:500;font-stretch:normal;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium Oblique'"
+   id="tspan933">S</tspan>θ</tspan></text>
+    <rect
+       style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1.1979419"
+       id="rect3146-6"
+       width="156.2706"
+       height="76.367538"
+       x="223.58075"
+       y="736.48651" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="240.23689"
+       y="775.39703"
+       id="text2985-4-0"><tspan
+         sodipodi:role="line"
+         id="tspan2987-8-10"
+         x="240.23689"
+         y="775.39703"
+         style="font-style:oblique;font-variant:normal;font-weight:500;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium Oblique'">S<tspan
+   style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium'"
+   id="tspan980"> = [  ]</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="265.60199"
+       y="804.6236"
+       id="text2989-9-2"><tspan
+         sodipodi:role="line"
+         id="tspan2991-9-5"
+         x="265.60199"
+         y="804.6236"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">screw axis</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="340.07523"
+       y="760.32709"
+       id="text988"><tspan
+         sodipodi:role="line"
+         id="tspan986"
+         x="340.07523"
+         y="760.32709"
+         style="font-size:21.33333397px;text-align:center;text-anchor:middle">ω</tspan><tspan
+         sodipodi:role="line"
+         x="340.07523"
+         y="781.6604"
+         id="tspan990"
+         style="font-size:21.33333397px;text-align:center;text-anchor:middle">v</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4)"
+       d="M 432,757.86218 H 377"
+       id="path5832-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-9)"
+       d="m 374.55862,779.86219 h 55"
+       id="path5832-4-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/doc/source/_static/transformations.svg
+++ b/doc/source/_static/transformations.svg
@@ -235,12 +235,12 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.4142136"
-     inkscape:cx="325.07013"
-     inkscape:cy="226.99603"
+     inkscape:zoom="2.0000001"
+     inkscape:cx="292.58013"
+     inkscape:cy="202.35027"
      inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="true"
+     inkscape:current-layer="g1330-4"
+     showgrid="false"
      inkscape:window-width="1920"
      inkscape:window-height="1015"
      inkscape:window-x="0"
@@ -278,14 +278,14 @@
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="422.40204"
+       x="374.40204"
        y="1014.3815"
        id="text2985"><tspan
          sodipodi:role="line"
          id="tspan2987"
-         x="422.40204"
+         x="374.40204"
          y="1014.3815"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:Serif;-inkscape-font-specification:Serif">T</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:Serif;-inkscape-font-specification:Serif">T = </tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
@@ -499,16 +499,18 @@
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="463.15613"
-       y="736.27271"
+       x="408.65613"
+       y="735.77271"
        id="text2985-4-0-6"><tspan
          sodipodi:role="line"
          id="tspan2987-8-10-7"
-         x="463.15613"
-         y="736.27271"
+         x="408.65613"
+         y="735.77271"
          style="font-style:oblique;font-variant:normal;font-weight:500;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium Oblique'"><tspan
            style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium'"
-           id="tspan970">[V]</tspan></tspan></text>
+           id="tspan970">[<tspan
+   style="font-style:oblique;font-variant:normal;font-weight:500;font-stretch:normal;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium Oblique'"
+   id="tspan1111">S</tspan>]=</tspan></tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
@@ -618,7 +620,7 @@
          style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-9-3)" />
     </g>
     <g
-       transform="translate(181.29271,70.99188)"
+       transform="translate(174.29271,72.49188)"
        id="g1175-8">
       <path
          sodipodi:nodetypes="cc"
@@ -724,6 +726,224 @@
          id="path5832-4-4-3-9"
          d="m 153.87816,659.55406 h 110"
          style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-9-6-1)" />
+    </g>
+    <g
+       id="g1330"
+       transform="matrix(0.53065276,0,0,0.53065276,163.03393,330.32263)">
+      <text
+         id="text1114"
+         y="720.32416"
+         x="630.44916"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle"
+           y="720.32416"
+           x="630.44916"
+           id="tspan1112"
+           sodipodi:role="line">0</tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1121"
+           y="738.99084"
+           x="630.44916"
+           sodipodi:role="line">ω<tspan
+   id="tspan1131"
+   style="font-size:64.99999762%;text-align:center;baseline-shift:sub;text-anchor:middle">3</tspan></tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1119"
+           y="757.65747"
+           x="630.44916"
+           sodipodi:role="line">-ω<tspan
+   id="tspan1135"
+   style="font-size:64.99999762%;text-align:center;baseline-shift:sub;text-anchor:middle">2</tspan></tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1125"
+           y="776.32416"
+           x="630.44916"
+           sodipodi:role="line">0</tspan></text>
+      <text
+         id="text1114-3"
+         y="720.32385"
+         x="664.53442"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle"
+           y="720.32385"
+           x="664.53442"
+           id="tspan1112-6"
+           sodipodi:role="line">-ω<tspan
+   id="tspan1127-7"
+   style="font-size:64.99999762%;text-align:center;baseline-shift:sub;text-anchor:middle">3</tspan></tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1121-5"
+           y="738.99054"
+           x="664.53442"
+           sodipodi:role="line">0</tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1119-1"
+           y="757.65717"
+           x="664.53442"
+           sodipodi:role="line">ω<tspan
+   id="tspan1137-7"
+   style="font-size:64.99999762%;text-align:center;baseline-shift:sub;text-anchor:middle">1</tspan></tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1125-9"
+           y="776.32385"
+           x="664.53442"
+           sodipodi:role="line">0</tspan></text>
+      <text
+         id="text1114-3-3"
+         y="720.32385"
+         x="698.78564"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle"
+           y="720.32385"
+           x="698.78564"
+           id="tspan1112-6-6"
+           sodipodi:role="line">ω<tspan
+   id="tspan1129-5-6"
+   style="font-size:64.99999762%;text-align:center;baseline-shift:sub;text-anchor:middle">2</tspan></tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1121-5-6"
+           y="738.99054"
+           x="698.78564"
+           sodipodi:role="line">-ω<tspan
+   id="tspan1133-2-1"
+   style="font-size:64.99999762%;text-align:center;baseline-shift:sub;text-anchor:middle">1</tspan></tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1119-1-7"
+           y="757.65717"
+           x="698.78564"
+           sodipodi:role="line">0</tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1125-9-0"
+           y="776.32385"
+           x="698.78564"
+           sodipodi:role="line">0</tspan></text>
+      <text
+         id="text2985-4-0-6-9"
+         y="761.92218"
+         x="594.60004"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:74.66666412px;line-height:1.25;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium'"
+           y="761.92218"
+           x="594.60004"
+           id="tspan2987-8-10-7-3"
+           sodipodi:role="line">[     ]</tspan></text>
+      <text
+         id="text1114-3-2"
+         y="720.32385"
+         x="728.72064"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle"
+           y="720.32385"
+           x="728.72064"
+           id="tspan1112-6-3"
+           sodipodi:role="line">v<tspan
+   id="tspan1143-3-9"
+   style="font-size:64.99999762%;text-align:center;baseline-shift:sub;text-anchor:middle">1</tspan></tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1121-5-2"
+           y="738.99054"
+           x="728.72064"
+           sodipodi:role="line">v<tspan
+   id="tspan1139-9-89"
+   style="font-size:64.99999762%;text-align:center;baseline-shift:sub;text-anchor:middle">2</tspan></tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1119-1-73"
+           y="757.65717"
+           x="728.72064"
+           sodipodi:role="line">v<tspan
+   id="tspan1141-0-1"
+   style="font-size:64.99999762%;text-align:center;baseline-shift:sub;text-anchor:middle">3</tspan></tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan1125-9-2"
+           y="776.32385"
+           x="728.72064"
+           sodipodi:role="line">0</tspan></text>
+    </g>
+    <g
+       id="g1330-4"
+       transform="matrix(0.53065276,0,0,0.53065276,107.75446,606.30276)">
+      <text
+         id="text2985-4-0-6-9-6"
+         y="763.33557"
+         x="625.22253"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:74.66666412px;line-height:1.25;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium'"
+           y="763.33557"
+           x="625.22253"
+           id="tspan2987-8-10-7-3-9"
+           sodipodi:role="line">[   ]</tspan></text>
+      <text
+         id="text1114-3-1-4"
+         y="775.64752"
+         x="713.07532"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:1"
+           id="tspan1125-9-6-4"
+           y="775.64752"
+           x="713.07532"
+           sodipodi:role="line">1</tspan></text>
+      <text
+         id="text1114-3-1-3"
+         y="775.64838"
+         x="683.3949"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:1"
+           id="tspan1125-9-6-0"
+           y="775.64838"
+           x="683.3949"
+           sodipodi:role="line">0</tspan></text>
+      <text
+         id="text1114-3-1-3-8"
+         y="775.64874"
+         x="669.02576"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:1"
+           id="tspan1125-9-6-0-4"
+           y="775.64874"
+           x="669.02576"
+           sodipodi:role="line">0</tspan></text>
+      <text
+         id="text1114-3-1-3-4"
+         y="775.6488"
+         x="654.42102"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+         xml:space="preserve"><tspan
+           style="text-align:center;text-anchor:middle;stroke-width:1"
+           id="tspan1125-9-6-0-9"
+           y="775.6488"
+           x="654.42102"
+           sodipodi:role="line">0</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.17679977px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.88447154"
+         x="650.40729"
+         y="750.21918"
+         id="text1540"><tspan
+           sodipodi:role="line"
+           id="tspan1538"
+           x="650.40729"
+           y="750.21918"
+           style="font-size:55.27783203px;stroke-width:1.88447154">R</tspan></text>
+      <text
+         id="text1114-3-1-4-2"
+         y="749.26532"
+         x="715.19537"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+         xml:space="preserve"><tspan
+           style="font-size:55.27783203px;text-align:center;text-anchor:middle;stroke-width:1"
+           id="tspan1125-9-6-4-0"
+           y="749.26532"
+           x="715.19537"
+           sodipodi:role="line">t</tspan></text>
     </g>
   </g>
 </svg>

--- a/doc/source/_static/transformations.svg
+++ b/doc/source/_static/transformations.svg
@@ -236,15 +236,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="2.0000001"
-     inkscape:cx="292.58013"
-     inkscape:cy="202.35027"
+     inkscape:cx="378.13446"
+     inkscape:cy="261.84139"
      inkscape:document-units="px"
-     inkscape:current-layer="g1330-4"
+     inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1920"
-     inkscape:window-height="1015"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-width="1528"
+     inkscape:window-height="836"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-right="0.8">
     <inkscape:grid
@@ -514,14 +514,14 @@
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="450.52124"
+       x="420.52124"
        y="766.99927"
        id="text2989-9-2-3"><tspan
          sodipodi:role="line"
          id="tspan2991-9-5-5"
-         x="450.52124"
+         x="420.52124"
          y="766.99927"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">unit twist</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">screw matrix</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"

--- a/doc/source/_static/transformations.svg
+++ b/doc/source/_static/transformations.svg
@@ -10,7 +10,7 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="600"
-   height="400"
+   height="500"
    id="svg2"
    version="1.1"
    inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
@@ -20,15 +20,16 @@
     <marker
        inkscape:stockid="Arrow1Lend"
        orient="auto"
-       refY="0.0"
-       refX="0.0"
+       refY="0"
+       refX="0"
        id="Arrow1Lend"
-       style="overflow:visible;">
+       style="overflow:visible">
       <path
          id="path3927"
-         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt;"
-         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
     </marker>
     <marker
        inkscape:stockid="Arrow1Lend"
@@ -58,6 +59,174 @@
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
          transform="matrix(-0.8,0,0,-0.8,-10,0)" />
     </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-6"
+       style="overflow:visible">
+      <path
+         id="path3927-4"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker988"
+       style="overflow:visible">
+      <path
+         id="path986"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-9-3"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-9-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-97"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-4"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-7"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-0"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-9-6"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-9-0"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-94"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-9-5"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-9-4"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-97-3"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-4-8"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-9-3-5"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-9-7-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-7-2"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-0-9"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-4-9-6-1"
+       style="overflow:visible">
+      <path
+         inkscape:connector-curvature="0"
+         id="path3927-2-9-0-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -66,12 +235,12 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.0000001"
-     inkscape:cx="278.52516"
-     inkscape:cy="205.53037"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="325.07013"
+     inkscape:cy="226.99603"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
-     showgrid="false"
+     showgrid="true"
      inkscape:window-width="1920"
      inkscape:window-height="1015"
      inkscape:window-x="0"
@@ -90,7 +259,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -98,57 +267,57 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-652.36218)">
+     transform="translate(0,-552.36218)">
     <rect
        style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1.18933082"
        id="rect3148"
        width="193.04015"
        height="74.246208"
-       x="212.41631"
-       y="954.27539" />
+       x="338.1615"
+       y="974.97235" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="296.65686"
-       y="993.68451"
+       x="422.40204"
+       y="1014.3815"
        id="text2985"><tspan
          sodipodi:role="line"
          id="tspan2987"
-         x="296.65686"
-         y="993.68451"
+         x="422.40204"
+         y="1014.3815"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:Serif;-inkscape-font-specification:Serif">T</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="221.15686"
-       y="1016.1846"
+       x="346.90204"
+       y="1036.8815"
        id="text2989"><tspan
          sodipodi:role="line"
          id="tspan2991"
-         x="221.15686"
-         y="1016.1846"
+         x="346.90204"
+         y="1036.8815"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">transformation matrix</tspan></text>
     <rect
        style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none"
        id="rect3142"
        width="121.62237"
        height="86.974136"
-       x="24.325901"
-       y="810.73267" />
+       x="204.3259"
+       y="788.73267" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="38.956879"
-       y="867.35516"
+       x="218.95688"
+       y="845.35516"
        id="text2989-2"><tspan
          sodipodi:role="line"
          id="tspan2991-0"
-         x="38.956879"
-         y="867.35516"
+         x="218.95688"
+         y="845.35516"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">exponential</tspan><tspan
          sodipodi:role="line"
-         x="38.956879"
-         y="892.35516"
+         x="218.95688"
+         y="870.35516"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'"
          id="tspan913">coordinates</tspan></text>
     <rect
@@ -156,18 +325,18 @@
        id="rect3146"
        width="156.2706"
        height="76.367538"
-       x="425.85132"
-       y="736.48651" />
+       x="6"
+       y="615.99463" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="457.47803"
-       y="775.39703"
+       x="37.626709"
+       y="654.90515"
        id="text2985-4"><tspan
          sodipodi:role="line"
          id="tspan2987-8"
-         x="457.47803"
-         y="775.39703"
+         x="37.626709"
+         y="654.90515"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:Serif;-inkscape-font-specification:Serif"><tspan
    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Serif;-inkscape-font-specification:'Serif Bold'"
    id="tspan1076">q</tspan>, <tspan
@@ -176,90 +345,84 @@
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="437.87256"
-       y="804.6236"
+       x="18.02124"
+       y="684.13171"
        id="text2989-9"><tspan
          sodipodi:role="line"
          id="tspan2991-9"
-         x="437.87256"
-         y="804.6236"
+         x="18.02124"
+         y="684.13171"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">screw parameters</tspan></text>
-    <path
-       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
-       d="M 225.14423,947.20428 155.14066,881.44335"
-       id="path5280"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
-       d="m 130.31223,904.61492 72.832,68.58936"
-       id="path5464"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
-       d="M 82.06602,805.6616 216.41631,776.67023"
-       id="path5648"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
-       d="m 220.90159,807.19714 -65.76093,16.26345"
-       id="path5832"
-       inkscape:connector-curvature="0" />
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="723.98926"
-       y="581.19366"
-       id="text6016"
-       transform="rotate(43.92535)"><tspan
-         sodipodi:role="line"
-         id="tspan6018"
-         x="723.98926"
-         y="581.19366"
-         style="font-size:14px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">exponential map</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="726.43878"
-       y="507.87747"
-       id="text6016-5"
-       transform="rotate(43.92535)"><tspan
-         sodipodi:role="line"
-         id="tspan6018-1"
-         x="726.43878"
-         y="507.87747"
-         style="font-size:14px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">logarithmic map</tspan></text>
+    <g
+       id="g903"
+       transform="rotate(31.927998,40.333261,1130.6084)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5280"
+         d="M 225.14423,829.20428 155.14066,763.44335"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5464"
+         d="m 130.31223,786.61492 72.832,68.58936"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)" />
+      <text
+         transform="rotate(43.92535)"
+         id="text6016"
+         y="496.20474"
+         x="642.13025"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="font-size:14px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'"
+           y="496.20474"
+           x="642.13025"
+           id="tspan6018"
+           sodipodi:role="line">exponential map</tspan></text>
+      <text
+         transform="rotate(43.92535)"
+         id="text6016-5"
+         y="422.88867"
+         x="644.57977"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="font-size:14px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'"
+           y="422.88867"
+           x="644.57977"
+           id="tspan6018-1"
+           sodipodi:role="line">logarithmic map</tspan></text>
+    </g>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="1.1923866"
-       y="703.03064"
+       y="587.03064"
        id="text6041"><tspan
          sodipodi:role="line"
          id="tspan6043"
          x="1.1923866"
-         y="703.03064"
+         y="587.03064"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:40px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'Sans Bold'">pytransform3d.transformations</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="497.44278"
-       y="767.1839"
+       x="77.591461"
+       y="646.69202"
        id="text2985-4-4"><tspan
          sodipodi:role="line"
          id="tspan2987-8-1"
-         x="497.44278"
-         y="767.1839"
+         x="77.591461"
+         y="646.69202"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif">^</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="60.528168"
-       y="845.71411"
+       x="240.52817"
+       y="823.71411"
        id="text2985-4-5"><tspan
          sodipodi:role="line"
          id="tspan2987-8-6"
-         x="60.528168"
-         y="845.71411"
+         x="240.52817"
+         y="823.71411"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:Serif;-inkscape-font-specification:Serif"><tspan
    style="font-style:oblique;font-variant:normal;font-weight:500;font-stretch:normal;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium Oblique'"
    id="tspan933">S</tspan>θ</tspan></text>
@@ -268,59 +431,299 @@
        id="rect3146-6"
        width="156.2706"
        height="76.367538"
-       x="223.58075"
-       y="736.48651" />
+       x="203.7294"
+       y="675.99463" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="240.23689"
-       y="775.39703"
+       x="220.38553"
+       y="714.90515"
        id="text2985-4-0"><tspan
          sodipodi:role="line"
          id="tspan2987-8-10"
-         x="240.23689"
-         y="775.39703"
+         x="220.38553"
+         y="714.90515"
          style="font-style:oblique;font-variant:normal;font-weight:500;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium Oblique'">S<tspan
    style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium'"
    id="tspan980"> = [  ]</tspan></tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="265.60199"
-       y="804.6236"
+       x="245.75064"
+       y="744.13171"
        id="text2989-9-2"><tspan
          sodipodi:role="line"
          id="tspan2991-9-5"
-         x="265.60199"
-         y="804.6236"
+         x="245.75064"
+         y="744.13171"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">screw axis</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="340.07523"
-       y="760.32709"
+       x="320.22388"
+       y="699.83521"
        id="text988"><tspan
          sodipodi:role="line"
          id="tspan986"
-         x="340.07523"
-         y="760.32709"
-         style="font-size:21.33333397px;text-align:center;text-anchor:middle">ω</tspan><tspan
+         x="320.22388"
+         y="699.83521"
+         style="font-size:21.33333397px;text-align:center;text-anchor:middle;-inkscape-font-specification:'CMU Bright Bold';font-family:'CMU Bright';font-weight:bold;font-style:normal;font-stretch:normal;font-variant:normal">ω</tspan><tspan
          sodipodi:role="line"
-         x="340.07523"
-         y="781.6604"
+         x="320.22388"
+         y="721.16852"
          id="tspan990"
-         style="font-size:21.33333397px;text-align:center;text-anchor:middle">v</tspan></text>
-    <path
-       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4)"
-       d="M 432,757.86218 H 377"
-       id="path5832-4"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-9)"
-       d="m 374.55862,779.86219 h 55"
-       id="path5832-4-4"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+         style="font-size:21.33333397px;text-align:center;text-anchor:middle;-inkscape-font-specification:'CMU Bright Bold';font-family:'CMU Bright';font-weight:bold;font-style:normal;font-stretch:normal;font-variant:normal">v</tspan></text>
+    <g
+       id="g1175"
+       transform="rotate(-146.96796,204.54875,681.00539)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4"
+         d="m 236.14867,637.37029 h -55"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-4"
+         d="m 187.00814,661.12983 h 55"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-9)" />
+    </g>
+    <rect
+       style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1.1979419"
+       id="rect3146-6-3"
+       width="156.2706"
+       height="76.367538"
+       x="410"
+       y="698.36218" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="463.15613"
+       y="736.27271"
+       id="text2985-4-0-6"><tspan
+         sodipodi:role="line"
+         id="tspan2987-8-10-7"
+         x="463.15613"
+         y="736.27271"
+         style="font-style:oblique;font-variant:normal;font-weight:500;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium Oblique'"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium'"
+           id="tspan970">[V]</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="450.52124"
+       y="766.99927"
+       id="text2989-9-2-3"><tspan
+         sodipodi:role="line"
+         id="tspan2991-9-5-5"
+         x="450.52124"
+         y="766.99927"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">unit twist</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.66666603px;line-height:1;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="369.49997"
+       y="741.86218"
+       id="text974"><tspan
+         sodipodi:role="line"
+         id="tspan972"
+         x="369.49997"
+         y="756.79553" /></text>
+    <g
+       id="g903-8"
+       transform="rotate(-122.18227,378.53882,774.98014)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5280-0"
+         d="M 225.14423,829.20428 155.14066,763.44335"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-6)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5464-8"
+         d="m 130.31223,786.61492 72.832,68.58936"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-6)" />
+      <text
+         transform="rotate(43.92535)"
+         id="text6016-1"
+         y="500.858"
+         x="649.22577"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="font-size:14px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'"
+           y="500.858"
+           x="649.22577"
+           id="tspan6018-0"
+           sodipodi:role="line">exponential map</tspan></text>
+      <text
+         transform="rotate(43.92535)"
+         id="text6016-5-2"
+         y="416.68433"
+         x="635.11908"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+         xml:space="preserve"><tspan
+           style="font-size:14px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'"
+           y="416.68433"
+           x="635.11908"
+           id="tspan6018-1-2"
+           sodipodi:role="line">logarithmic map</tspan></text>
+    </g>
+    <rect
+       style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1.1979419"
+       id="rect3146-6-3-9"
+       width="156.2706"
+       height="76.367538"
+       x="409.7294"
+       y="795.99463" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="452.88553"
+       y="833.90515"
+       id="text2985-4-0-6-7"><tspan
+         sodipodi:role="line"
+         id="tspan2987-8-10-7-5"
+         x="452.88553"
+         y="833.90515"
+         style="font-style:oblique;font-variant:normal;font-weight:500;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium Oblique'"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-family:'CMU Bright';-inkscape-font-specification:'CMU Bright Medium'"
+           id="tspan970-6">[<tspan
+   style="-inkscape-font-specification:'CMU Bright Medium Oblique';font-family:'CMU Bright';font-weight:500;font-style:oblique;font-stretch:normal;font-variant:normal"
+   id="tspan1461">S</tspan>]θ</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="420.25064"
+       y="864.63171"
+       id="text2989-9-2-3-4"><tspan
+         sodipodi:role="line"
+         id="tspan2991-9-5-5-6"
+         x="420.25064"
+         y="864.63171"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">matrix logarithm</tspan></text>
+    <g
+       id="g1171"
+       transform="rotate(-90,190,542.36218)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-9"
+         d="M -17.55862,650.36217 H -72.55861"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-97)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-4-1"
+         d="M -74.99999,672.36218 H -20"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-9-3)" />
+    </g>
+    <g
+       transform="translate(181.29271,70.99188)"
+       id="g1175-8">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-5"
+         d="m 236.14867,637.37029 h -55"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-7)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-4-3"
+         d="m 178.70729,659.3703 h 55"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-9-6)" />
+    </g>
+    <g
+       transform="translate(141.29271,172.99188)"
+       id="g1175-1">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-55"
+         d="m 272.14867,653.37029 h -91"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-94)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-4-4"
+         d="m 178.70729,675.3703 h 91"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-9-5)" />
+    </g>
+    <g
+       id="g1171-2"
+       transform="rotate(-90,317.50001,429.86219)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-9-2"
+         d="M -17.55862,650.36217 H -72.55861"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-97-3)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-4-1-7"
+         d="M -74.99999,672.36218 H -20"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-9-3-5)" />
+    </g>
+    <rect
+       style="opacity:0.3;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1.30591094"
+       id="rect3148-3"
+       width="203.64674"
+       height="84.852806"
+       x="27.930723"
+       y="962.91315" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="83.242332"
+       y="1005.3932"
+       id="text2985-6"><tspan
+         sodipodi:role="line"
+         id="tspan2987-7"
+         x="83.242332"
+         y="1005.3932"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:Serif;-inkscape-font-specification:Serif">(<tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Serif;-inkscape-font-specification:'Serif Bold'"
+   id="tspan1118">p</tspan>, <tspan
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Serif;-inkscape-font-specification:'Serif Bold'"
+   id="tspan1116">q</tspan>)</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="36.671265"
+       y="1037.4288"
+       id="text2989-5"><tspan
+         sodipodi:role="line"
+         id="tspan2991-3"
+         x="36.671265"
+         y="1037.4288"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:1.25;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman'">position and quaternion</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="140.52187"
+       y="993.49823"
+       id="text2985-4-4-5"><tspan
+         sodipodi:role="line"
+         id="tspan2987-8-1-6"
+         x="140.52187"
+         y="993.49823"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif">^</tspan></text>
+    <g
+       transform="translate(76.121835,365.80812)"
+       id="g1175-8-7">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-5-0"
+         d="m 263.87816,636.55406 h -110"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-7-2)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5832-4-4-3-9"
+         d="m 153.87816,659.55406 h 110"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-4-9-6-1)" />
+    </g>
   </g>
 </svg>

--- a/doc/source/_templates/class_without_inherited.rst
+++ b/doc/source/_templates/class_without_inherited.rst
@@ -5,7 +5,7 @@
 .. autoclass:: {{ objname }}
    :members:
    :show-inheritance:
-   :inherited-members:
+   :no-inherited-members:
 
    {% block methods %}
    .. automethod:: __init__
@@ -15,7 +15,9 @@
 
    .. autosummary::
    {% for item in methods %}
-      ~{{ name }}.{{ item }}
+       {% if item not in inherited_members %}
+          ~{{ name }}.{{ item }}
+       {% endif %}
    {%- endfor %}
    {% endif %}
    {% endblock %}
@@ -26,7 +28,9 @@
 
    .. autosummary::
    {% for item in attributes %}
-      ~{{ name }}.{{ item }}
+       {% if item not in inherited_members %}
+          ~{{ name }}.{{ item }}
+       {% endif %}
    {%- endfor %}
    {% endif %}
    {% endblock %}

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -186,6 +186,7 @@ Create Transformations
    ~pytransform3d.transformations.screw_axis_from_screw_parameters
    ~pytransform3d.transformations.screw_parameters_from_screw_axis
    ~pytransform3d.transformations.transform_from_exponential_coordinates
+   ~pytransform3d.transformations.exponential_coordinates_from_transform
 
 Apply Transformations
 ---------------------

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -180,7 +180,7 @@ Input Validation Functions
    ~pytransform3d.transformations.check_screw_parameters
    ~pytransform3d.transformations.check_screw_axis
    ~pytransform3d.transformations.check_exponential_coordinates
-   ~pytransform3d.transformations.check_unit_twist
+   ~pytransform3d.transformations.check_screw_matrix
    ~pytransform3d.transformations.check_transform_log
 
 Conversions to Transformation Matrix
@@ -225,7 +225,7 @@ Conversions to Screw Axis
 
    ~pytransform3d.transformations.screw_axis_from_screw_parameters
    ~pytransform3d.transformations.screw_axis_from_exponential_coordinates
-   ~pytransform3d.transformations.screw_axis_from_unit_twist
+   ~pytransform3d.transformations.screw_axis_from_screw_matrix
 
 Conversions to Exponential Coordinates
 --------------------------------------
@@ -245,8 +245,8 @@ Conversions to Unit Twist Matrix
    :toctree: _apidoc/
    :template: function.rst
 
-   ~pytransform3d.transformations.unit_twist_from_screw_axis
-   ~pytransform3d.transformations.unit_twist_from_transform_log
+   ~pytransform3d.transformations.screw_matrix_from_screw_axis
+   ~pytransform3d.transformations.screw_matrix_from_transform_log
 
 Conversions to Matrix Logarithm
 -------------------------------
@@ -256,7 +256,7 @@ Conversions to Matrix Logarithm
    :template: function.rst
 
    ~pytransform3d.transformations.transform_log_from_exponential_coordinates
-   ~pytransform3d.transformations.transform_log_from_unit_twist
+   ~pytransform3d.transformations.transform_log_from_screw_matrix
    ~pytransform3d.transformations.transform_log_from_transform
 
 Apply Transformations

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -324,7 +324,7 @@ Testing
 
 .. autosummary::
    :toctree: _apidoc/
-   :template: class.rst
+   :template: class_without_inherited.rst
 
    ~pytransform3d.editor.TransformEditor
 
@@ -382,7 +382,7 @@ Testing
 
 .. autosummary::
    :toctree: _apidoc/
-   :template: class.rst
+   :template: class_without_inherited.rst
 
    ~pytransform3d.plot_utils.Arrow3D
    ~pytransform3d.plot_utils.Frame

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -43,6 +43,7 @@ Input Validation Functions
    :template: function.rst
 
    ~pytransform3d.rotations.check_matrix
+   ~pytransform3d.rotations.check_skew_symmetric_matrix
    ~pytransform3d.rotations.check_axis_angle
    ~pytransform3d.rotations.check_compact_axis_angle
    ~pytransform3d.rotations.check_quaternion

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -4,7 +4,7 @@
 API Documentation
 =================
 
-You can search for specific modules, classes or functions in the
+You can search for specific modules, classes, or functions in the
 :ref:`genindex`.
 
 
@@ -229,8 +229,8 @@ Conversions to Exponential Coordinates
    ~pytransform3d.transformations.exponential_coordinates_from_screw_axis
    ~pytransform3d.transformations.exponential_coordinates_from_transform_log
 
-Conversions to Unit Twist
--------------------------
+Conversions to Unit Twist Matrix
+--------------------------------
 
 .. autosummary::
    :toctree: _apidoc/

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -158,6 +158,16 @@ Testing
     :no-members:
     :no-inherited-members:
 
+Utility Functions
+-----------------
+
+.. autosummary::
+   :toctree: _apidoc/
+   :template: function.rst
+
+   ~pytransform3d.transformations.random_transform
+   ~pytransform3d.transformations.random_screw_axis
+
 Input Validation Functions
 --------------------------
 
@@ -182,7 +192,6 @@ Conversions to Transformation Matrix
 
 
    ~pytransform3d.transformations.transform_from
-   ~pytransform3d.transformations.random_transform
    ~pytransform3d.transformations.translate_transform
    ~pytransform3d.transformations.rotate_transform
    ~pytransform3d.transformations.transform_from_pq

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -169,6 +169,7 @@ Input Validation Functions
    ~pytransform3d.transformations.check_screw_parameters
    ~pytransform3d.transformations.check_screw_axis
    ~pytransform3d.transformations.check_exponential_coordinates
+   ~pytransform3d.transformations.check_unit_twist
 
 Conversions to Transformation Matrix
 ------------------------------------

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -166,6 +166,9 @@ Input Validation Functions
 
    ~pytransform3d.transformations.check_transform
    ~pytransform3d.transformations.check_pq
+   ~pytransform3d.transformations.check_screw_parameters
+   ~pytransform3d.transformations.check_screw_axis
+   ~pytransform3d.transformations.check_exponential_coordinates
 
 Create Transformations
 ----------------------
@@ -180,6 +183,9 @@ Create Transformations
    ~pytransform3d.transformations.rotate_transform
    ~pytransform3d.transformations.pq_from_transform
    ~pytransform3d.transformations.transform_from_pq
+   ~pytransform3d.transformations.screw_axis_from_screw_parameters
+   ~pytransform3d.transformations.screw_parameters_from_screw_axis
+   ~pytransform3d.transformations.transform_from_exponential_coordinates
 
 Apply Transformations
 ---------------------
@@ -205,6 +211,7 @@ Plotting
    :template: function.rst
 
    ~pytransform3d.transformations.plot_transform
+   ~pytransform3d.transformations.plot_screw
 
 Testing
 -------

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -184,7 +184,7 @@ Conversions to Transformation Matrix
    ~pytransform3d.transformations.rotate_transform
    ~pytransform3d.transformations.transform_from_pq
    ~pytransform3d.transformations.transform_from_exponential_coordinates
-   ~pytransform3d.transformations.transform_from_matrix_log
+   ~pytransform3d.transformations.transform_from_transform_log
 
 Conversions to Position and Quaternion
 --------------------------------------
@@ -224,7 +224,7 @@ Conversions to Exponential Coordinates
 
    ~pytransform3d.transformations.exponential_coordinates_from_transform
    ~pytransform3d.transformations.exponential_coordinates_from_screw_axis
-   ~pytransform3d.transformations.exponential_coordinates_from_matrix_log
+   ~pytransform3d.transformations.exponential_coordinates_from_transform_log
 
 Conversions to Unit Twist
 -------------------------
@@ -234,7 +234,7 @@ Conversions to Unit Twist
    :template: function.rst
 
    ~pytransform3d.transformations.unit_twist_from_screw_axis
-   ~pytransform3d.transformations.unit_twist_from_matrix_log
+   ~pytransform3d.transformations.unit_twist_from_transform_log
 
 Conversions to Matrix Logarithm
 -------------------------------
@@ -243,9 +243,9 @@ Conversions to Matrix Logarithm
    :toctree: _apidoc/
    :template: function.rst
 
-   ~pytransform3d.transformations.matrix_log_from_exponential_coordinates
-   ~pytransform3d.transformations.matrix_log_from_unit_twist
-   ~pytransform3d.transformations.matrix_log_from_transform
+   ~pytransform3d.transformations.transform_log_from_exponential_coordinates
+   ~pytransform3d.transformations.transform_log_from_unit_twist
+   ~pytransform3d.transformations.transform_log_from_transform
 
 Apply Transformations
 ---------------------

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -170,6 +170,7 @@ Input Validation Functions
    ~pytransform3d.transformations.check_screw_axis
    ~pytransform3d.transformations.check_exponential_coordinates
    ~pytransform3d.transformations.check_unit_twist
+   ~pytransform3d.transformations.check_transform_log
 
 Conversions to Transformation Matrix
 ------------------------------------

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -28,6 +28,7 @@ Utility Functions
    ~pytransform3d.rotations.norm_compact_axis_angle
    ~pytransform3d.rotations.perpendicular_to_vectors
    ~pytransform3d.rotations.angle_between_vectors
+   ~pytransform3d.rotations.vector_projection
    ~pytransform3d.rotations.random_vector
    ~pytransform3d.rotations.random_axis_angle
    ~pytransform3d.rotations.random_compact_axis_angle

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -170,23 +170,82 @@ Input Validation Functions
    ~pytransform3d.transformations.check_screw_axis
    ~pytransform3d.transformations.check_exponential_coordinates
 
-Create Transformations
-----------------------
+Conversions to Transformation Matrix
+------------------------------------
 
 .. autosummary::
    :toctree: _apidoc/
    :template: function.rst
 
+
    ~pytransform3d.transformations.transform_from
    ~pytransform3d.transformations.random_transform
    ~pytransform3d.transformations.translate_transform
    ~pytransform3d.transformations.rotate_transform
-   ~pytransform3d.transformations.pq_from_transform
    ~pytransform3d.transformations.transform_from_pq
-   ~pytransform3d.transformations.screw_axis_from_screw_parameters
-   ~pytransform3d.transformations.screw_parameters_from_screw_axis
    ~pytransform3d.transformations.transform_from_exponential_coordinates
+   ~pytransform3d.transformations.transform_from_matrix_log
+
+Conversions to Position and Quaternion
+--------------------------------------
+
+.. autosummary::
+   :toctree: _apidoc/
+   :template: function.rst
+
+   ~pytransform3d.transformations.pq_from_transform
+
+Conversions to Screw Parameters
+-------------------------------
+
+.. autosummary::
+   :toctree: _apidoc/
+   :template: function.rst
+
+   ~pytransform3d.transformations.screw_parameters_from_screw_axis
+
+Conversions to Screw Axis
+-------------------------
+
+.. autosummary::
+   :toctree: _apidoc/
+   :template: function.rst
+
+   ~pytransform3d.transformations.screw_axis_from_screw_parameters
+   ~pytransform3d.transformations.screw_axis_from_exponential_coordinates
+   ~pytransform3d.transformations.screw_axis_from_unit_twist
+
+Conversions to Exponential Coordinates
+--------------------------------------
+
+.. autosummary::
+   :toctree: _apidoc/
+   :template: function.rst
+
    ~pytransform3d.transformations.exponential_coordinates_from_transform
+   ~pytransform3d.transformations.exponential_coordinates_from_screw_axis
+   ~pytransform3d.transformations.exponential_coordinates_from_matrix_log
+
+Conversions to Unit Twist
+-------------------------
+
+.. autosummary::
+   :toctree: _apidoc/
+   :template: function.rst
+
+   ~pytransform3d.transformations.unit_twist_from_screw_axis
+   ~pytransform3d.transformations.unit_twist_from_matrix_log
+
+Conversions to Matrix Logarithm
+-------------------------------
+
+.. autosummary::
+   :toctree: _apidoc/
+   :template: function.rst
+
+   ~pytransform3d.transformations.matrix_log_from_exponential_coordinates
+   ~pytransform3d.transformations.matrix_log_from_unit_twist
+   ~pytransform3d.transformations.matrix_log_from_transform
 
 Apply Transformations
 ---------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,6 +10,7 @@ import sphinx_bootstrap_theme
 
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     #'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
@@ -18,12 +19,17 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.autosummary',
     'matplotlib.sphinxext.plot_directive',
     'numpydoc',
 ]
 
-templates_path = ['_templates']
+autodoc_default_options = {"member-order": "bysource"}
+autosummary_generate = True  # generate files at doc/source/_apidoc
+class_members_toctree = False
+numpydoc_show_class_members = False
+
+# class template from https://stackoverflow.com/a/62613202/915743
+templates_path = ["_templates"]
 exclude_patterns = []
 exclude_trees = ["_templates", "sphinxext"]
 source_suffix = '.rst'
@@ -48,7 +54,10 @@ html_show_sourcelink = False
 html_show_sphinx = False
 html_show_copyright = True
 
-autosummary_generate = True
-autodoc_default_options = {"member-order": "bysource"}
-
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/{.major}'.format(
+        sys.version_info), None),
+    'numpy': ('https://numpy.org/doc/stable', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+    'matplotlib': ('https://matplotlib.org/', None)
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,7 +12,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
-    #'sphinx.ext.intersphinx',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     #'sphinx.ext.mathjax',
@@ -61,3 +61,4 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org/', None)
 }
+intersphinx_timeout = 10

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,19 +9,17 @@ pytransform3d
 
 pytransform3d covers the following groups of transformations.
 
-+-------+-----------------+-----------+---------------------+
-| Group | Description     | Dimension | Representation      |
-+=======+=================+===========+=====================+
-| SO(3) | 3D rotations    | 3         | unit quaternion,    |
-|       |                 |           | rotation matrix,    |
-|       |                 |           | axis-angle,         |
-|       |                 |           | Euler angles        |
-+-------+-----------------+-----------+---------------------+
-| SE(3) | 3D rigid        | 6         | transformation      |
-|       | transformations |           | matrix, translation |
-|       | (translation +  |           | + unit quaternion   |
-|       | rotation)       |           |                     |
-+-------+-----------------+-----------+---------------------+
++-------+------------------+-----------+------------------------------------+
+| Group | Description      | Dimension | Representation                     |
++=======+==================+===========+====================================+
+| SO(3) | 3D rotations     | 3         | unit quaternion, rotation matrix,  |
+|       |                  |           | axis-angle, Euler angles           |
++-------+------------------+-----------+------------------------------------+
+| SE(3) | 3D rigid body    | 6         | transformation matrix, translation |
+|       | transformations  |           | and unit quaternion, exponential   |
+|       | (translation and |           | coordinates, logarithm of          |
+|       | rotation)        |           | transformation                     |
++-------+------------------+-----------+------------------------------------+
 
 In this documentation we will use the notation :math:`_A\boldsymbol{t}_{BC}`
 to represent a vector from frame B to frame C expressed in frame A.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -41,12 +41,3 @@ Table of Contents
    camera
    animations
    api
-
-----------
-References
-----------
-
-* Representing Robot Pose: The good, the bad, and the ugly (slides): http://static.squarespace.com/static/523c5c56e4b0abc2df5e163e/t/53957839e4b05045ad65021d/1402304569659/Workshop+-+Rotations_v102.key.pdf 
-* Representing Robot Pose: The good, the bad, and the ugly (blog): http://paulfurgale.info/news/2014/6/9/representing-robot-pose-the-good-the-bad-and-the-ugly
-* Kindr cheat sheet: https://docs.leggedrobotics.com/kindr/cheatsheet_latest.pdf
-* Why and How to Avoid the Flipped Quaternion Multiplication: https://arxiv.org/pdf/1801.07478.pdf

--- a/doc/source/rotations.rst
+++ b/doc/source/rotations.rst
@@ -1,5 +1,5 @@
 ===================
-3D Rotations: SO(3)
+SO(3): 3D Rotations
 ===================
 
 The group of all rotations in the 3D Cartesian space is called :math:`SO(3)`

--- a/doc/source/rotations.rst
+++ b/doc/source/rotations.rst
@@ -156,6 +156,31 @@ It is possible to write this in a more compact way as a rotation vector:
 
     \boldsymbol{\omega} = \theta \hat{\boldsymbol{\omega}}
 
+We can also refer to this representation as **exponential coordinates of
+rotation**. In addition, we can represent it by the cross-product matrix
+
+.. math::
+
+    \left[\hat{\boldsymbol{\omega}}\right] \theta
+    =
+    \left(
+    \begin{matrix}
+    0 & -\omega_3 & \omega_2\\
+    \omega_3 & 0 & -\omega_1\\
+    -\omega_2 & \omega_1 & 0\\
+    \end{matrix}
+    \right)
+    \theta
+    \in so(3)
+    \subset \mathbb{R}^{3 \times 3},
+
+where :math:`\left[\hat{\boldsymbol{\omega}}\right] \theta` is the matrix
+logarithm of a rotation matrix and :math:`so(3)` is the Lie algebra of
+the Lie group :math:`SO(3)`. We can easily represent angular velocity as
+:math:`\dot{\theta} \hat{\boldsymbol{\omega}}`
+and angular acceleration as
+:math:`\ddot{\theta} \hat{\boldsymbol{\omega}}`.
+
 **Pros**
 
 * Minimal representation (as rotation vector, also referred to as compact axis-angle in the code)

--- a/doc/source/rotations.rst
+++ b/doc/source/rotations.rst
@@ -6,7 +6,7 @@ The group of all rotations in the 3D Cartesian space is called :math:`SO(3)`
 (SO: special orthogonal group).
 The minimum number of components that are required to describe any rotation
 from :math:`SO(3)` is 3. However, there is no representation that is
-non-redundant, continuous and free of singularities. We will now take a closer
+non-redundant, continuous, and free of singularities. We will now take a closer
 look at competing representations of rotations and the orientations they can
 describe.
 
@@ -150,48 +150,25 @@ by a scalar:
 
 .. math::
 
-    \left( \boldsymbol{\hat{e}}, \theta \right) = \left( \left( \begin{array}{c}e_x\\e_y\\e_z\end{array} \right), \theta \right)
+    \left( \hat{\boldsymbol{\omega}}, \theta \right) = \left( \left( \begin{array}{c}\omega_x\\\omega_y\\\omega_z\end{array} \right), \theta \right)
 
 It is possible to write this in a more compact way as a rotation vector:
 
 .. math::
 
-    \boldsymbol{v} = \theta \boldsymbol{\hat{e}}
+    \boldsymbol{\omega} = \theta \hat{\boldsymbol{\omega}}
 
 **Pros**
 
 * Minimal representation (as rotation vector, also referred to as compact axis-angle in the code)
 * It is easy to interpret the representation (as axis and angle)
+* Can also represent angular velocity and acceleration when we replace
+  :math:`\theta` by :math:`\dot{\theta}` or :math:`\ddot{\theta}` respectively,
+  which makes numerical integration and differentiation easy.
 
 **Cons**
 
 * Concatenation involves conversion to another representation
-
-------------
-Euler Angles
-------------
-
-A complete rotation can be split into three rotations around basis vectors.
-
-.. warning::
-
-    There are 24 different conventions for defining euler angles. There are
-    12 different valid ways to sequence rotation axes that can be interpreted
-    as extrinsic or intrinsic rotations: XZX, XYX, YXY, YZY, ZYZ, ZXZ, XZY,
-    XYZ, YXZ, YZX, ZYX, and ZXY. We will only use the XYZ convention and the
-    ZYX convention with intrinsic rotations.
-
-.. plot:: ../../examples/plot_euler_angles.py
-    :include-source:
-
-**Pros**
-
-* Minimal representation
-
-**Cons**
-
-* 24 different conventions
-* Singularities (gimbal lock)
 
 -----------
 Quaternions
@@ -227,9 +204,9 @@ The following equation describes its relation to axis-axis notation.
     \left( \begin{array}{c} w\\ x\\ y\\ z\\ \end{array} \right) =
     \left( \begin{array}{c}
         \cos \frac{\theta}{2}\\
-        e_x \sin \frac{\theta}{2}\\
-        e_y \sin \frac{\theta}{2}\\
-        e_z \sin \frac{\theta}{2}\\
+        \omega_x \sin \frac{\theta}{2}\\
+        \omega_y \sin \frac{\theta}{2}\\
+        \omega_z \sin \frac{\theta}{2}\\
     \end{array} \right)
 
 .. warning::
@@ -260,3 +237,29 @@ The following equation describes its relation to axis-axis notation.
 * The representation is not straightforward to interpret
 * There are always two unit quaternions that represent exactly the same
   rotation
+
+------------
+Euler Angles
+------------
+
+A complete rotation can be split into three rotations around basis vectors.
+
+.. warning::
+
+    There are 24 different conventions for defining euler angles. There are
+    12 different valid ways to sequence rotation axes that can be interpreted
+    as extrinsic or intrinsic rotations: XZX, XYX, YXY, YZY, ZYZ, ZXZ, XZY,
+    XYZ, YXZ, YZX, ZYX, and ZXY. We will only use the XYZ convention and the
+    ZYX convention with intrinsic rotations.
+
+.. plot:: ../../examples/plot_euler_angles.py
+    :include-source:
+
+**Pros**
+
+* Minimal representation
+
+**Cons**
+
+* 24 different conventions
+* Singularities (gimbal lock)

--- a/doc/source/rotations.rst
+++ b/doc/source/rotations.rst
@@ -140,11 +140,9 @@ by applying the rotation
 Axis-Angle
 ----------
 
-Each rotation can be represented by a single rotation around one axis.
-
 .. plot:: ../../examples/plot_axis_angle.py
-    :include-source:
 
+Each rotation can be represented by a single rotation around one axis.
 The axis can be represented as a three-dimensional unit vector and the angle
 by a scalar:
 

--- a/doc/source/rotations.rst
+++ b/doc/source/rotations.rst
@@ -184,7 +184,9 @@ and an imaginary / vector part
 
     There are two different quaternion conventions: Hamilton's convention
     defines :math:`ijk = -1` and the JPL convention (from NASA's Jet Propulsion
-    Laboratory, JPL) defines :math:`ijk = 1`. We use Hamilton's convention.
+    Laboratory, JPL) defines :math:`ijk = 1`.
+    These two conventions result in different multiplication operations and
+    conversions to other representations. We use Hamilton's convention.
 
 Read `this paper <https://arxiv.org/pdf/1801.07478.pdf>`_ for details about the
 two conventions and why Hamilton's convention should be used. Section VI A
@@ -261,3 +263,12 @@ A complete rotation can be split into three rotations around basis vectors.
 
 * 24 different conventions
 * Singularities (gimbal lock)
+
+----------
+References
+----------
+
+* Representing Robot Pose: The good, the bad, and the ugly (slides): http://static.squarespace.com/static/523c5c56e4b0abc2df5e163e/t/53957839e4b05045ad65021d/1402304569659/Workshop+-+Rotations_v102.key.pdf
+* Representing Robot Pose: The good, the bad, and the ugly (blog): http://paulfurgale.info/news/2014/6/9/representing-robot-pose-the-good-the-bad-and-the-ugly
+* Kindr cheat sheet: https://docs.leggedrobotics.com/kindr/cheatsheet_latest.pdf
+* Why and How to Avoid the Flipped Quaternion Multiplication: https://arxiv.org/pdf/1801.07478.pdf

--- a/doc/source/rotations.rst
+++ b/doc/source/rotations.rst
@@ -3,12 +3,12 @@ SO(3): 3D Rotations
 ===================
 
 The group of all rotations in the 3D Cartesian space is called :math:`SO(3)`
-(SO: special orthogonal group).
-The minimum number of components that are required to describe any rotation
-from :math:`SO(3)` is 3. However, there is no representation that is
-non-redundant, continuous, and free of singularities. We will now take a closer
-look at competing representations of rotations and the orientations they can
-describe.
+(SO: special orthogonal group). It is typically represented by 3D rotations
+matrices. The minimum number of components that are required to describe
+any rotation from :math:`SO(3)` is 3. However, there is no representation that
+is non-redundant, continuous, and free of singularities. We will now take a
+closer look at competing representations of rotations and the orientations they
+can describe.
 
 Here is an overview of the representations and the conversions between them
 that are available in pytransform3d.

--- a/doc/source/transformation_ambiguities.rst
+++ b/doc/source/transformation_ambiguities.rst
@@ -310,8 +310,9 @@ of a local, body-fixed coordinates (intrinsic rotation) by
 in which :math:`R_2` is applied. Note that this applies to both
 passive and active rotation matrices.
 
+Here is a comparison between various conventions of concatenation.
+
 .. plot:: ../../examples/plot_convention_rotation_global_local.py
-    :include-source:
 
 .. note::
 

--- a/doc/source/transformations.rst
+++ b/doc/source/transformations.rst
@@ -13,9 +13,7 @@ an analogous representation of transformations:
   matrix :math:`\boldsymbol R`.
 * A **screw axis** :math:`\mathcal S` is similar to a rotation axis
   :math:`\hat{\boldsymbol{\omega}}`.
-* A **twist** :math:`\mathcal V = \mathcal{S} \dot{\theta}` is similar to
-  angular velocity :math:`\hat{\boldsymbol{\omega}} \dot{\theta}`.
-* A **unit twist matrix** :math:`\left[\mathcal{S}\right]` is similar to
+* A **screw matrix** :math:`\left[\mathcal{S}\right]` is similar to
   a cross-product matrix of a unit rotation axis
   :math:`\left[\hat{\boldsymbol{\omega}}\right]`.
 * The **logarithm of a transformation** :math:`\left[\mathcal{S}\right] \theta`
@@ -25,6 +23,8 @@ an analogous representation of transformations:
   are similar to exponential coordinates
   :math:`\hat{\boldsymbol{\omega}} \theta` for rotations (axis-angle
   representation).
+* A **twist** :math:`\mathcal V = \mathcal{S} \dot{\theta}` is similar to
+  angular velocity :math:`\hat{\boldsymbol{\omega}} \dot{\theta}`.
 
 Here is an overview of the representations and the conversions between them
 that are available in pytransform3d.
@@ -170,9 +170,9 @@ Alternatively, we can represent a screw axis :math:`\mathcal S` in a matrix
     \in \mathbb{R}^{4 \times 4}
 
 that contains the cross-product matrix of its orientation part and its
-translation part. This is the **matrix representation of a unit twist** and
-we will also refer to it as unit twist in the API. By multiplication with
-:math:`\theta` we can again generate a full description of a transformation
+translation part. This is the **matrix representation of a screw axis** and
+we will also refer to it as **screw matrix** in the API. By multiplication
+with :math:`\theta` we can again generate a full description of a transformation
 :math:`\left[\mathcal{S}\right] \theta`, which is the **matrix logarithm of
 a transformation matrix**.
 

--- a/doc/source/transformations.rst
+++ b/doc/source/transformations.rst
@@ -173,8 +173,19 @@ that contains the cross-product matrix of its orientation part and its
 translation part. This is the **matrix representation of a screw axis** and
 we will also refer to it as **screw matrix** in the API. By multiplication
 with :math:`\theta` we can again generate a full description of a transformation
-:math:`\left[\mathcal{S}\right] \theta`, which is the **matrix logarithm of
-a transformation matrix**.
+:math:`\left[\mathcal{S}\right] \theta \in se(3)`, which is the **matrix
+logarithm of a transformation matrix** and :math:`se(3)` is the Lie algebra of
+Lie group :math:`SE(3)`.
+
+-----
+Twist
+-----
+
+We call spatial velocity (translation and rotation) **twist**. Similarly
+to the matrix logarithm, a twist :math:`\mathcal{V} = \mathcal{S} \dot{\theta}`
+is described by a screw axis :math:`S` and a scalar :math:`\dot{\theta}`
+and :math:`\left[\mathcal{V}\right] = \left[\mathcal{S}\right] \theta \in se(3)`
+is the matrix representation of a twist.
 
 ----------
 References

--- a/doc/source/transformations.rst
+++ b/doc/source/transformations.rst
@@ -121,14 +121,15 @@ where either
 2. :math:`||\boldsymbol{\omega}|| = 0` and :math:`||\boldsymbol{v}|| = 1`
    (only translation).
 
-In case 1 we can compute the screw axis from screw parameters
+In case 1, we can compute the screw axis from screw parameters
 :math:`(\boldsymbol{q}, \hat{\boldsymbol{s}}, h)` as
 
 .. math::
 
     \mathcal{S} = \left[ \begin{array}{c}\hat{\boldsymbol{s}} \\ \boldsymbol{q} \times \hat{\boldsymbol{s}} + h \hat{\boldsymbol{s}}\end{array} \right]
 
-In case 2 ... TODO
+In case 2, :math:`h` is infinite and we directly translate along :math:`\hat{\boldsymbol{s}}`.
 
 With the additional parameter :math:`\theta` we can then define a complete
 transformation through its exponential coordinates :math:`\mathcal{S} \theta`.
+This is a minimal representation as it only needs 6 values.

--- a/doc/source/transformations.rst
+++ b/doc/source/transformations.rst
@@ -1,5 +1,5 @@
 =========================
-3D Transformations: SE(3)
+SE(3): 3D Transformations
 =========================
 
 The group of all transformations in the 3D Cartesian space is :math:`SE(3)`
@@ -9,15 +9,23 @@ represented in different ways just like rotations can be expressed
 in different ways. For most representations of orientations we can find
 an analogous representation of transformations:
 
-* A **transformation matrix** :math:`\boldsymbol T` is analogous to a rotation
+* A **transformation matrix** :math:`\boldsymbol T` is similar to a rotation
   matrix :math:`\boldsymbol R`.
-* A **screw axis** :math:`\mathcal S` is analogous to a rotation axis :math:`\hat{\omega}`.
-* A **twist** :math:`\mathcal V = \mathcal{S} \dot{\theta}` is analogous to
+* A **screw axis** :math:`\mathcal S` is similar to a rotation axis
+  :math:`\hat{\boldsymbol{\omega}}`.
+* A **twist** :math:`\mathcal V = \mathcal{S} \dot{\theta}` is similar to
   angular velocity :math:`\hat{\boldsymbol{\omega}} \dot{\theta}`.
 * Exponential coordinates :math:`\mathcal{S} \theta` for rigid body motions
-  are analogous to exponential coordinates
+  are similar to exponential coordinates
   :math:`\hat{\boldsymbol{\omega}} \theta` for rotations (axis-angle
   representation).
+
+Here is an overview of the representations and the conversions between them
+that are available in pytransform3d.
+
+.. image:: _static/transformations.svg
+   :alt: Transformations
+   :align: center
 
 ---------------------
 Transformation Matrix

--- a/doc/source/transformations.rst
+++ b/doc/source/transformations.rst
@@ -100,21 +100,24 @@ a 2D array.
 Exponential Coordinates
 -----------------------
 
+.. plot:: ../../examples/plot_screw.py
+
 Just like any rotation can be expressed as a rotation by an angle about a
 3D unit vector, any transformation (rotation and translation) can be expressed
-by a motion along a screw axis. A screw axis is represented by a point vector
-:math:`\boldsymbol{q}` through which the screw axis passes, a (unit) direction
-vector :math:`\hat{\boldsymbol{s}}` that indicates the direction of the axis,
-and the pitch :math:`h`. The pitch represents the ratio of translation and
-rotation. A screw motion translates along the screw axis and rotates about it.
+by a motion along a screw axis. The **screw parameters** that describe a screw
+axis include a point vector :math:`\boldsymbol{q}` through which the screw
+axis passes, a (unit) direction vector :math:`\hat{\boldsymbol{s}}` that
+indicates the direction of the axis, and the pitch :math:`h`. The pitch
+represents the ratio of translation and rotation. A screw motion translates
+along the screw axis and rotates about it.
 
 .. image:: _static/screw_axis.svg
    :alt: Screw axis
    :width: 80%
    :align: center
 
-A screw axis is typically represented by
-:math:`\mathcal{S} = \left[\begin{array}{c}\boldsymbol{\omega}\\\boldsymbol{v}\end{array}\right]`,
+A **screw axis** is typically represented by
+:math:`\mathcal{S} = \left[\begin{array}{c}\boldsymbol{\omega}\\\boldsymbol{v}\end{array}\right] \in \mathbb{R}^6`,
 where either
 
 1. :math:`||\boldsymbol{\omega}|| = 1` or
@@ -130,6 +133,14 @@ In case 1, we can compute the screw axis from screw parameters
 
 In case 2, :math:`h` is infinite and we directly translate along :math:`\hat{\boldsymbol{s}}`.
 
-With the additional parameter :math:`\theta` we can then define a complete
-transformation through its exponential coordinates :math:`\mathcal{S} \theta`.
+By multiplication with an additional parameter :math:`\theta` we can then
+define a complete transformation through its exponential coordinates
+:math:`\mathcal{S} \theta = \left[\begin{array}{c}\boldsymbol{\omega}\theta\\\boldsymbol{v}\theta\end{array}\right] \in \mathbb{R}^6`.
 This is a minimal representation as it only needs 6 values.
+
+----------
+References
+----------
+
+Lynch, Park: Modern Robotics (Section 3.3); available at
+http://hades.mech.northwestern.edu/index.php/Modern_Robotics

--- a/doc/source/transformations.rst
+++ b/doc/source/transformations.rst
@@ -5,7 +5,19 @@
 The group of all transformations in the 3D Cartesian space is :math:`SE(3)`
 (SE: special Euclidean group).
 Transformations consist of a rotation and a translation. Those can be
-represented in multiple different ways.
+represented in different ways just like rotations can be expressed
+in different ways. For most representations of orientations we can find
+an analogous representation of transformations:
+
+* A **transformation matrix** :math:`\boldsymbol T` is analogous to a rotation
+  matrix :math:`\boldsymbol R`.
+* A **screw axis** :math:`\mathcal S` is analogous to a rotation axis :math:`\hat{\omega}`.
+* A **twist** :math:`\mathcal V = \mathcal{S} \dot{\theta}` is analogous to
+  angular velocity :math:`\hat{\boldsymbol{\omega}} \dot{\theta}`.
+* Exponential coordinates :math:`\mathcal{S} \theta` for rigid body motions
+  are analogous to exponential coordinates
+  :math:`\hat{\boldsymbol{\omega}} \theta` for rotations (axis-angle
+  representation).
 
 ---------------------
 Transformation Matrix
@@ -22,10 +34,20 @@ the form
         \boldsymbol R & \boldsymbol t\\
         \boldsymbol 0 & 1\\
     \end{array} \right)
+    =
+    \left(
+    \begin{matrix}
+    r_{11} & r_{12} & r_{13} & t_1\\
+    r_{21} & r_{22} & r_{23} & t_2\\
+    r_{31} & r_{32} & r_{33} & t_3\\
+    0 & 0 & 0 & 1\\
+    \end{matrix}
+    \right)
 
 It is a partitioned matrix with a 3x3 rotation matrix :math:`\boldsymbol R`
 and a column vector :math:`\boldsymbol t` that represents the translation.
 It is also sometimes called the homogeneous representation of a transformation.
+All transformation matrices form the special Euclidean group :math:`SE(3)`.
 
 It is possible to transform position vectors or direction vectors with it.
 Position vectors are represented as a column vector
@@ -43,7 +65,7 @@ will give the following result:
 .. math::
 
     \boldsymbol T_{AB} \boldsymbol p_B =
-    \left( \begin{array}{cc}
+    \left( \begin{array}{c}
         \boldsymbol R \boldsymbol p_B + \boldsymbol t\\
         1\\
     \end{array} \right)
@@ -62,4 +84,43 @@ quaternion:
         x\\y\\z\\q_w\\q_x\\q_y\\q_z
     \end{array} \right)
 
-This representation is more compact than a transformation matrix.
+This representation is more compact than a transformation matrix and is
+particularly useful if you want to represent a sequence of poses in
+a 2D array.
+
+-----------------------
+Exponential Coordinates
+-----------------------
+
+Just like any rotation can be expressed as a rotation by an angle about a
+3D unit vector, any transformation (rotation and translation) can be expressed
+by a motion along a screw axis. A screw axis is represented by a point vector
+:math:`\boldsymbol{q}` through which the screw axis passes, a (unit) direction
+vector :math:`\hat{\boldsymbol{s}}` that indicates the direction of the axis,
+and the pitch :math:`h`. The pitch represents the ratio of translation and
+rotation. A screw motion translates along the screw axis and rotates about it.
+
+.. image:: _static/screw_axis.svg
+   :alt: Screw axis
+   :width: 80%
+   :align: center
+
+A screw axis is typically represented by
+:math:`\mathcal{S} = \left[\begin{array}{c}\boldsymbol{\omega}\\\boldsymbol{v}\end{array}\right]`,
+where either
+
+1. :math:`||\boldsymbol{\omega}|| = 1` or
+2. :math:`||\boldsymbol{\omega}|| = 0` and :math:`||\boldsymbol{v}|| = 1`
+   (only translation).
+
+In case 1 we can compute the screw axis from screw parameters
+:math:`(\boldsymbol{q}, \hat{\boldsymbol{s}}, h)` as
+
+.. math::
+
+    \mathcal{S} = \left[ \begin{array}{c}\hat{\boldsymbol{s}} \\ \boldsymbol{q} \times \hat{\boldsymbol{s}} + h \hat{\boldsymbol{s}}\end{array} \right]
+
+In case 2 ... TODO
+
+With the additional parameter :math:`\theta` we can then define a complete
+transformation through its exponential coordinates :math:`\mathcal{S} \theta`.

--- a/doc/source/transformations.rst
+++ b/doc/source/transformations.rst
@@ -144,6 +144,38 @@ define a complete transformation through its exponential coordinates
 :math:`\mathcal{S} \theta = \left[\begin{array}{c}\boldsymbol{\omega}\theta\\\boldsymbol{v}\theta\end{array}\right] \in \mathbb{R}^6`.
 This is a minimal representation as it only needs 6 values.
 
+---------------------------
+Logarithm of Transformation
+---------------------------
+
+Alternatively, we can represent a screw axis :math:`\mathcal S` in a matrix
+
+.. math::
+
+    \left[\mathcal S\right]
+    =
+    \left( \begin{array}{cc}
+        \left[\boldsymbol{\omega}\right] & \boldsymbol v\\
+        \boldsymbol 0 & 0\\
+    \end{array} \right)
+    =
+    \left(
+    \begin{matrix}
+    0 & -\omega_3 & \omega_2 & v_1\\
+    \omega_3 & 0 & -\omega_1 & v_2\\
+    -\omega_2 & \omega_1 & 0 & v_3\\
+    0 & 0 & 0 & 0\\
+    \end{matrix}
+    \right)
+    \in \mathbb{R}^{4 \times 4}
+
+that contains the cross-product matrix of its orientation part and its
+translation part. This is the **matrix representation of a unit twist** and
+we will also refer to it as unit twist in the API. By multiplication with
+:math:`\theta` we can again generate a full description of a transformation
+:math:`\left[\mathcal{S}\right] \theta`, which is the **matrix logarithm of
+a transformation matrix**.
+
 ----------
 References
 ----------

--- a/doc/source/transformations.rst
+++ b/doc/source/transformations.rst
@@ -15,6 +15,12 @@ an analogous representation of transformations:
   :math:`\hat{\boldsymbol{\omega}}`.
 * A **twist** :math:`\mathcal V = \mathcal{S} \dot{\theta}` is similar to
   angular velocity :math:`\hat{\boldsymbol{\omega}} \dot{\theta}`.
+* A **unit twist matrix** :math:`\left[\mathcal{S}\right]` is similar to
+  a cross-product matrix of a unit rotation axis
+  :math:`\left[\hat{\boldsymbol{\omega}}\right]`.
+* The **logarithm of a transformation** :math:`\left[\mathcal{S}\right] \theta`
+  is similar to a cross-product matrix of the angle-axis representation
+  :math:`\left[\hat{\boldsymbol{\omega}}\right] \theta`.
 * Exponential coordinates :math:`\mathcal{S} \theta` for rigid body motions
   are similar to exponential coordinates
   :math:`\hat{\boldsymbol{\omega}} \theta` for rotations (axis-angle

--- a/examples/plot_screw.py
+++ b/examples/plot_screw.py
@@ -1,23 +1,44 @@
-"""TODO"""
+"""
+========================================
+Plot Transformation through Screw Motion
+========================================
+
+A screw axis is represented by the parameters (q, s_axis, h). We can represent
+any transformation with a screw axis and an additional parameter theta that
+encodes the rotation angle and through h * theta the translation. Here we
+visualize a screw axis and the transformation generated from a specific
+theta.
+
+The larger coordinate frame represents the origin of the transformation
+and the smaller frame represents the transformed frame. The red point
+indicates the position of q, which is a point on the screw axis. A straight
+arrow shows the direction of the screw axis. The spiral path represents
+a displacement of length theta along the screw axis.
+"""
 print(__doc__)
 
 
 import numpy as np
 import matplotlib.pyplot as plt
 from pytransform3d.rotations import active_matrix_from_extrinsic_roll_pitch_yaw
-from pytransform3d.transformations import (plot_transform, plot_screw,
-                                           screw_axis_from_screw_parameters,
-                                           transform_from_exponential_coordinates,
-                                           concat, transform_from)
+from pytransform3d.transformations import (
+    plot_transform, plot_screw, screw_axis_from_screw_parameters,
+    transform_from_exponential_coordinates, concat, transform_from)
 
 
+# Screw parameters
 q = np.array([-0.2, -0.1, -0.5])
 s_axis = np.array([0, 0, 1])
 h = 0.05
 theta = 5.5 * np.pi
-Stheta = screw_axis_from_screw_parameters(q, s_axis, h, theta)
+
+Stheta = screw_axis_from_screw_parameters(q, s_axis, h) * theta
 A2B = transform_from_exponential_coordinates(Stheta)
-origin = transform_from(active_matrix_from_extrinsic_roll_pitch_yaw([0.5, -0.3, 0.2]), np.array([0.0, 0.1, 0.1]))
+
+origin = transform_from(
+    active_matrix_from_extrinsic_roll_pitch_yaw([0.5, -0.3, 0.2]),
+    np.array([0.0, 0.1, 0.1]))
+
 ax = plot_transform(A2B=origin, s=0.4)
 plot_transform(ax=ax, A2B=concat(A2B, origin), s=0.2)
 plot_screw(ax=ax, q=q, s_axis=s_axis, h=h, theta=theta, A2B=origin, s=1.5, alpha=0.6)

--- a/examples/plot_screw.py
+++ b/examples/plot_screw.py
@@ -4,16 +4,22 @@ print(__doc__)
 
 import numpy as np
 import matplotlib.pyplot as plt
-from pytransform3d.transformations import plot_transform, plot_screw, screw_axis_from_screw_parameters, transform_from_exponential_coordinates
+from pytransform3d.rotations import active_matrix_from_extrinsic_roll_pitch_yaw
+from pytransform3d.transformations import (plot_transform, plot_screw,
+                                           screw_axis_from_screw_parameters,
+                                           transform_from_exponential_coordinates,
+                                           concat, transform_from)
 
 
 q = np.array([-0.2, -0.1, -0.5])
 s_axis = np.array([0, 0, 1])
-h = 0.1
-theta = 2.5 * np.pi
+h = 0.05
+theta = 5.5 * np.pi
 Stheta = screw_axis_from_screw_parameters(q, s_axis, h, theta)
 A2B = transform_from_exponential_coordinates(Stheta)
-ax = plot_transform(s=0.4)
-plot_transform(ax=ax, A2B=A2B, s=0.2)
-ax = plot_screw(ax=ax, q=q, s_axis=s_axis, h=h, theta=theta)
+origin = transform_from(active_matrix_from_extrinsic_roll_pitch_yaw([0.5, -0.3, 0.2]), np.array([0.0, 0.1, 0.1]))
+ax = plot_transform(A2B=origin, s=0.4)
+plot_transform(ax=ax, A2B=concat(A2B, origin), s=0.2)
+plot_screw(ax=ax, q=q, s_axis=s_axis, h=h, theta=theta, A2B=origin, s=1.5, alpha=0.6)
+ax.view_init(elev=40, azim=170)
 plt.show()

--- a/examples/plot_screw.py
+++ b/examples/plot_screw.py
@@ -4,15 +4,16 @@ print(__doc__)
 
 import numpy as np
 import matplotlib.pyplot as plt
-from pytransform3d.transformations import plot_transform, plot_screw_motion, twist_from_screw_displacement, transform_from_twist_displacement, screw_displacement_from_twist
+from pytransform3d.transformations import plot_transform, plot_screw, screw_axis_from_screw_parameters, transform_from_exponential_coordinates
 
 
-q = np.array([-np.sqrt(0.3), -np.sqrt(0.3), -np.sqrt(0.3)])
+q = np.array([-0.2, -0.1, -0.5])
 s_axis = np.array([0, 0, 1])
-h = 0.2
-theta = 5.0
-#A2B = transform_from_twist_displacement(twist)
-ax = plot_transform(s=0.2)
-#plot_transform(ax=ax, A2B=A2B, s=0.2)
-ax = plot_screw_motion(ax=ax, q=q, s_axis=s_axis, h=h, theta=theta, s=0.5)
+h = 0.1
+theta = 2.5 * np.pi
+Stheta = screw_axis_from_screw_parameters(q, s_axis, h, theta)
+A2B = transform_from_exponential_coordinates(Stheta)
+ax = plot_transform(s=0.4)
+plot_transform(ax=ax, A2B=A2B, s=0.2)
+ax = plot_screw(ax=ax, q=q, s_axis=s_axis, h=h, theta=theta)
 plt.show()

--- a/examples/plot_screw.py
+++ b/examples/plot_screw.py
@@ -1,0 +1,18 @@
+"""TODO"""
+print(__doc__)
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+from pytransform3d.transformations import plot_transform, plot_screw_motion, twist_from_screw_displacement, transform_from_twist_displacement, screw_displacement_from_twist
+
+
+q = np.array([-np.sqrt(0.3), -np.sqrt(0.3), -np.sqrt(0.3)])
+s_axis = np.array([0, 0, 1])
+h = 0.2
+theta = 5.0
+#A2B = transform_from_twist_displacement(twist)
+ax = plot_transform(s=0.2)
+#plot_transform(ax=ax, A2B=A2B, s=0.2)
+ax = plot_screw_motion(ax=ax, q=q, s_axis=s_axis, h=h, theta=theta, s=0.5)
+plt.show()

--- a/pytransform3d/__init__.py
+++ b/pytransform3d/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.4'
+__version__ = '1.5-dev'

--- a/pytransform3d/camera.py
+++ b/pytransform3d/camera.py
@@ -1,4 +1,7 @@
-"""Transformations related to cameras."""
+"""Transformations related to cameras.
+
+See :doc:`camera` for more information.
+"""
 import numpy as np
 from .transformations import invert_transform, transform
 

--- a/pytransform3d/rotations.py
+++ b/pytransform3d/rotations.py
@@ -1,4 +1,7 @@
-"""Rotations in three dimensions - SO(3)."""
+"""Rotations in three dimensions - SO(3).
+
+See :doc:`rotations` for more information.
+"""
 import warnings
 import math
 import numpy as np

--- a/pytransform3d/rotations.py
+++ b/pytransform3d/rotations.py
@@ -333,6 +333,13 @@ def check_skew_symmetric_matrix(V, tolerance=1e-6, strict_check=True):
     V : array-like, shape (3, 3)
         Cross-product matrix
 
+    tolerance : float, optional (default: 1e-6)
+        Tolerance threshold for checks.
+
+    strict_check : bool, optional (default: True)
+        Raise a ValueError if V.T is not numerically close enough to -V.
+        Otherwise we print a warning.
+
     Returns
     -------
     V : array-like, shape (3, 3)

--- a/pytransform3d/rotations.py
+++ b/pytransform3d/rotations.py
@@ -319,6 +319,39 @@ def cross_product_matrix(v):
                      [-v[1], v[0], 0.0]])
 
 
+def check_skew_symmetric_matrix(V, tolerance=1e-6, strict_check=True):
+    """Input validation of a skew-symmetric matrix.
+
+    Check whether the transpose of the matrix is its negative:
+
+    .. math::
+
+        A^T = -A
+
+    Parameters
+    ----------
+    V : array-like, shape (3, 3)
+        Cross-product matrix
+
+    Returns
+    -------
+    V : array-like, shape (3, 3)
+        Validated cross-product matrix
+    """
+    V = np.asarray(V, dtype=np.float)
+    if V.ndim != 2 or V.shape[0] != 3 or V.shape[1] != 3:
+        raise ValueError("Expected skew-symmetric matrix with shape (3, 3), "
+                         "got array-like object with shape %s" % (V.shape,))
+    if not np.allclose(V.T, -V, atol=tolerance):
+        error_msg = ("Expected skew-symmetric matrix, but it failed the test "
+                     "V.T = %r\n-V = %r" % (V.T, -V))
+        if strict_check:
+            raise ValueError(error_msg)
+        else:
+            warnings.warn(error_msg)
+    return V
+
+
 def check_matrix(R, tolerance=1e-6, strict_check=True):
     """Input validation of a rotation matrix.
 

--- a/pytransform3d/rotations.py
+++ b/pytransform3d/rotations.py
@@ -186,6 +186,28 @@ def angle_between_vectors(a, b, fast=False):
         return np.arctan2(np.linalg.norm(np.cross(a, b)), np.dot(a, b))
 
 
+def vector_projection(a, b):
+    """Orthogonal projection of vector a on vector b.
+
+    Parameters
+    ----------
+    a : array-like, shape (3,)
+        Vector a that will be projected on vector b
+
+    b : array-like, shape (3,)
+        Vector b on which vector a will be projected
+
+    Returns
+    -------
+    a_on_b : array, shape (3,)
+        Vector a
+    """
+    b_norm_squared = np.dot(b, b)
+    if b_norm_squared == 0.0:
+        return np.zeros(3)
+    return np.dot(a, b) * b / b_norm_squared
+
+
 def random_vector(random_state=np.random.RandomState(0), n=3):
     """Generate an nd vector with normally distributed components.
 
@@ -1565,7 +1587,7 @@ def plot_axis_angle(ax=None, a=a_id, p=p0, s=1.0, ax_s=1, **kwargs):
 
     angle_p1p2 = angle_between_vectors(p1, p2)
     arc = np.empty((100, 3))
-    for i, t in enumerate(np.linspace(0, 2 * a[3] / np.pi, 100)):
+    for i, t in enumerate(np.linspace(0, 2 * a[3] / np.pi, len(arc))):
         w1, w2 = _slerp_weights(angle_p1p2, t)
         arc[i] = p + 0.5 * s * (a[:3] + w1 * p1 + w2 * p2)
     ax.plot(arc[:-5, 0], arc[:-5, 1], arc[:-5, 2], color="k", lw=3, **kwargs)

--- a/pytransform3d/rotations.py
+++ b/pytransform3d/rotations.py
@@ -329,7 +329,7 @@ def check_skew_symmetric_matrix(V, tolerance=1e-6, strict_check=True):
 
     .. math::
 
-        A^T = -A
+        V^T = -V
 
     Parameters
     ----------

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -157,6 +157,47 @@ def test_angle_to_zero_vector_is_nan():
     assert_true(np.isnan(angle))
 
 
+def test_vector_projection_on_zero_vector():
+    """Test projection on zero vector."""
+    random_state = np.random.RandomState(23)
+    for _ in range(5):
+        a = random_vector(random_state, 3)
+        a_on_b = vector_projection(a, np.zeros(3))
+        assert_array_almost_equal(a_on_b, np.zeros(3))
+
+
+def test_vector_projection():
+    """Test orthogonal projection of one vector to another vector."""
+    a = np.ones(3)
+    a_on_unitx = vector_projection(a, unitx)
+    assert_array_almost_equal(a_on_unitx, unitx)
+    assert_almost_equal(angle_between_vectors(a_on_unitx, unitx), 0.0)
+
+    a2_on_unitx = vector_projection(2 * a, unitx)
+    assert_array_almost_equal(a2_on_unitx, 2 * unitx)
+    assert_almost_equal(angle_between_vectors(a2_on_unitx, unitx), 0.0)
+
+    a_on_unity = vector_projection(a, unity)
+    assert_array_almost_equal(a_on_unity, unity)
+    assert_almost_equal(angle_between_vectors(a_on_unity, unity), 0.0)
+
+    minus_a_on_unity = vector_projection(-a, unity)
+    assert_array_almost_equal(minus_a_on_unity, -unity)
+    assert_almost_equal(angle_between_vectors(minus_a_on_unity, unity), np.pi)
+
+    a_on_unitz = vector_projection(a, unitz)
+    assert_array_almost_equal(a_on_unitz, unitz)
+    assert_almost_equal(angle_between_vectors(a_on_unitz, unitz), 0.0)
+
+    unitz_on_a = vector_projection(unitz, a)
+    assert_array_almost_equal(unitz_on_a, np.ones(3) / 3.0)
+    assert_almost_equal(angle_between_vectors(unitz_on_a, a), 0.0)
+
+    unitx_on_unitx = vector_projection(unitx, unitx)
+    assert_array_almost_equal(unitx_on_unitx, unitx)
+    assert_almost_equal(angle_between_vectors(unitx_on_unitx, unitx), 0.0)
+
+
 def test_cross_product_matrix():
     """Test cross-product matrix."""
     random_state = np.random.RandomState(0)

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -198,6 +198,28 @@ def test_vector_projection():
     assert_almost_equal(angle_between_vectors(unitx_on_unitx, unitx), 0.0)
 
 
+def test_check_skew_symmetric_matrix():
+    assert_raises_regexp(
+        ValueError, "Expected skew-symmetric matrix with shape",
+        check_skew_symmetric_matrix, [])
+    assert_raises_regexp(
+        ValueError, "Expected skew-symmetric matrix with shape",
+        check_skew_symmetric_matrix, np.zeros((3, 4)))
+    assert_raises_regexp(
+        ValueError, "Expected skew-symmetric matrix with shape",
+        check_skew_symmetric_matrix, np.zeros((4, 3)))
+    V = np.zeros((3, 3))
+    V[0, 0] = 0.001
+    assert_raises_regexp(
+        ValueError, "Expected skew-symmetric matrix, but it failed the test",
+        check_skew_symmetric_matrix, V)
+    with warnings.catch_warnings(record=True) as w:
+        check_skew_symmetric_matrix(V, strict_check=False)
+        assert_equal(len(w), 1)
+
+    check_skew_symmetric_matrix(np.zeros((3, 3)))
+
+
 def test_cross_product_matrix():
     """Test cross-product matrix."""
     random_state = np.random.RandomState(0)
@@ -205,6 +227,7 @@ def test_cross_product_matrix():
         v = random_vector(random_state)
         w = random_vector(random_state)
         V = cross_product_matrix(v)
+        check_skew_symmetric_matrix(V)
         r1 = np.cross(v, w)
         r2 = np.dot(V, w)
         assert_array_almost_equal(r1, r2)

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -28,7 +28,7 @@ from pytransform3d.transformations import (random_transform, transform_from,
                                            unit_twist_from_transform_log,
                                            transform_from_transform_log,
                                            transform_log_from_transform,
-                                           check_unit_twist)
+                                           check_unit_twist, check_transform_log)
 from pytransform3d.rotations import (matrix_from, random_axis_angle,
                                      random_vector, axis_angle_from_matrix,
                                      norm_vector, perpendicular_to_vector,
@@ -379,6 +379,27 @@ def test_check_unit_twist():
         np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]))
     unit_twist2 = check_unit_twist(unit_twist)
     assert_array_almost_equal(unit_twist, unit_twist2)
+
+
+def test_check_transform_log():
+    assert_raises_regexp(
+        ValueError, "Expected array-like with shape", check_transform_log,
+        np.zeros((1, 4, 4)))
+    assert_raises_regexp(
+        ValueError, "Expected array-like with shape", check_transform_log,
+        np.zeros((3, 4)))
+    assert_raises_regexp(
+        ValueError, "Expected array-like with shape", check_transform_log,
+        np.zeros((4, 3)))
+
+    assert_raises_regexp(
+        ValueError, "Last row of logarithm of transformation must only "
+                    "contains zeros",
+        check_transform_log, np.eye(4))
+    transform_log = unit_twist_from_screw_axis(
+        np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])) * 1.1
+    transform_log2 = check_transform_log(transform_log)
+    assert_array_almost_equal(transform_log, transform_log2)
 
 
 def test_random_screw_axis():

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -25,7 +25,9 @@ from pytransform3d.transformations import (random_transform, transform_from,
                                            unit_twist_from_screw_axis,
                                            screw_axis_from_unit_twist,
                                            transform_log_from_unit_twist,
-                                           unit_twist_from_transform_log)
+                                           unit_twist_from_transform_log,
+                                           transform_from_transform_log,
+                                           transform_log_from_transform)
 from pytransform3d.rotations import (matrix_from, random_axis_angle,
                                      random_vector, axis_angle_from_matrix,
                                      norm_vector, perpendicular_to_vector,
@@ -472,3 +474,23 @@ def test_conversions_between_unit_twist_and_transform_log():
         V2, theta2 = unit_twist_from_transform_log(transform_log)
         assert_array_almost_equal(V, V2)
         assert_almost_equal(theta, theta2)
+
+
+def test_conversions_between_transform_and_transform_log():
+    A2B = np.eye(4)
+    transform_log = transform_log_from_transform(A2B)
+    assert_array_almost_equal(transform_log, np.zeros((4, 4)))
+    A2B2 = transform_from_transform_log(transform_log)
+    assert_array_almost_equal(A2B, A2B2)
+
+    random_state = np.random.RandomState(84)
+    A2B = transform_from(np.eye(3), p=random_vector(random_state, 3))
+    transform_log = transform_log_from_transform(A2B)
+    A2B2 = transform_from_transform_log(transform_log)
+    assert_array_almost_equal(A2B, A2B2)
+
+    for _ in range(5):
+        A2B = random_transform(random_state)
+        transform_log = transform_log_from_transform(A2B)
+        A2B2 = transform_from_transform_log(transform_log)
+        assert_array_almost_equal(A2B, A2B2)

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -289,6 +289,11 @@ def test_check_screw_parameters():
     assert_array_almost_equal(s_axis, s_axis2)
     assert_almost_equal(h, h2)
 
+    q2, s_axis2, h2 = check_screw_parameters(q, s_axis, np.inf)
+    assert_array_almost_equal(np.zeros(3), q2)
+    assert_array_almost_equal(s_axis, s_axis2)
+    assert_almost_equal(np.inf, h2)
+
 
 def test_check_screw_axis():
     random_state = np.random.RandomState(73)
@@ -376,10 +381,6 @@ def test_conversions_between_exponential_coordinates_and_transform():
     random_state = np.random.RandomState(52)
     for _ in range(5):
         A2B = random_transform(random_state)
-        print(A2B)
         Stheta = exponential_coordinates_from_transform(A2B)
-        print(Stheta)
         A2B2 = transform_from_exponential_coordinates(Stheta)
-        print(A2B2)
-        print(np.round(A2B - A2B2, 4))
         assert_array_almost_equal(A2B, A2B2)

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -380,6 +380,13 @@ def test_check_unit_twist():
     unit_twist2 = check_unit_twist(unit_twist)
     assert_array_almost_equal(unit_twist, unit_twist2)
 
+    unit_twist = unit_twist_from_screw_axis(
+        np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0]))
+    unit_twist[0, 0] = 0.0001
+    assert_raises_regexp(
+        ValueError, "Expected skew-symmetric matrix",
+        check_unit_twist, unit_twist)
+
 
 def test_check_transform_log():
     assert_raises_regexp(
@@ -400,6 +407,13 @@ def test_check_transform_log():
         np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])) * 1.1
     transform_log2 = check_transform_log(transform_log)
     assert_array_almost_equal(transform_log, transform_log2)
+
+    transform_log = unit_twist_from_screw_axis(
+        np.array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])) * 1.1
+    transform_log[0, 0] = 0.0001
+    assert_raises_regexp(
+        ValueError, "Expected skew-symmetric matrix",
+        check_transform_log, transform_log)
 
 
 def test_random_screw_axis():

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -488,8 +488,7 @@ def test_conversions_between_screw_axis_and_exponential_coordinates():
 
     S = np.zeros(6)
     theta = 0.0
-    Stheta = exponential_coordinates_from_screw_axis(S, theta)
-    S2, theta2 = screw_axis_from_exponential_coordinates(Stheta)
+    S2, theta2 = screw_axis_from_exponential_coordinates(np.zeros(6))
     assert_array_almost_equal(S, S2)
     assert_almost_equal(theta, theta2)
 

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -19,7 +19,13 @@ from pytransform3d.transformations import (random_transform, transform_from,
                                            exponential_coordinates_from_transform,
                                            random_screw_axis,
                                            exponential_coordinates_from_screw_axis,
-                                           screw_axis_from_exponential_coordinates)
+                                           screw_axis_from_exponential_coordinates,
+                                           transform_log_from_exponential_coordinates,
+                                           exponential_coordinates_from_transform_log,
+                                           unit_twist_from_screw_axis,
+                                           screw_axis_from_unit_twist,
+                                           transform_log_from_unit_twist,
+                                           unit_twist_from_transform_log)
 from pytransform3d.rotations import (matrix_from, random_axis_angle,
                                      random_vector, axis_angle_from_matrix,
                                      norm_vector, perpendicular_to_vector,
@@ -418,4 +424,51 @@ def test_conversions_between_screw_axis_and_exponential_coordinates():
         Stheta = exponential_coordinates_from_screw_axis(S, theta)
         S2, theta2 = screw_axis_from_exponential_coordinates(Stheta)
         assert_array_almost_equal(S, S2)
+        assert_almost_equal(theta, theta2)
+
+
+def test_conversions_between_exponential_coordinates_and_transform_log():
+    random_state = np.random.RandomState(22)
+    for _ in range(5):
+        Stheta = random_state.randn(6)
+        transform_log = transform_log_from_exponential_coordinates(Stheta)
+        Stheta2 = exponential_coordinates_from_transform_log(transform_log)
+        assert_array_almost_equal(Stheta, Stheta2)
+
+
+def test_conversions_between_unit_twist_and_screw_axis():
+    random_state = np.random.RandomState(83)
+    for _ in range(5):
+        S = random_screw_axis(random_state)
+        V = unit_twist_from_screw_axis(S)
+        S2 = screw_axis_from_unit_twist(V)
+        assert_array_almost_equal(S, S2)
+
+
+def test_conversions_between_unit_twist_and_transform_log():
+    V = np.array([[0.0, 0.0, 0.0, 1.0],
+                  [0.0, 0.0, 0.0, 0.0],
+                  [0.0, 0.0, 0.0, 0.0],
+                  [0.0, 0.0, 0.0, 0.0]])
+    theta = 1.0
+    transform_log = transform_log_from_unit_twist(V, theta)
+    V2, theta2 = unit_twist_from_transform_log(transform_log)
+    assert_array_almost_equal(V, V2)
+    assert_almost_equal(theta, theta2)
+
+    V = np.zeros((4, 4))
+    theta = 0.0
+    transform_log = transform_log_from_unit_twist(V, theta)
+    V2, theta2 = unit_twist_from_transform_log(transform_log)
+    assert_array_almost_equal(V, V2)
+    assert_almost_equal(theta, theta2)
+
+    random_state = np.random.RandomState(65)
+    for _ in range(5):
+        S = random_screw_axis(random_state)
+        theta = np.random.rand()
+        V = unit_twist_from_screw_axis(S)
+        transform_log = transform_log_from_unit_twist(V, theta)
+        V2, theta2 = unit_twist_from_transform_log(transform_log)
+        assert_array_almost_equal(V, V2)
         assert_almost_equal(theta, theta2)

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -16,7 +16,10 @@ from pytransform3d.transformations import (random_transform, transform_from,
                                            screw_axis_from_screw_parameters,
                                            screw_parameters_from_screw_axis,
                                            transform_from_exponential_coordinates,
-                                           exponential_coordinates_from_transform)
+                                           exponential_coordinates_from_transform,
+                                           random_screw_axis,
+                                           exponential_coordinates_from_screw_axis,
+                                           screw_axis_from_exponential_coordinates)
 from pytransform3d.rotations import (matrix_from, random_axis_angle,
                                      random_vector, axis_angle_from_matrix,
                                      norm_vector, perpendicular_to_vector,
@@ -384,3 +387,35 @@ def test_conversions_between_exponential_coordinates_and_transform():
         Stheta = exponential_coordinates_from_transform(A2B)
         A2B2 = transform_from_exponential_coordinates(Stheta)
         assert_array_almost_equal(A2B, A2B2)
+
+
+def test_random_screw_axis():
+    random_state = np.random.RandomState(893)
+    for _ in range(5):
+        S = random_screw_axis(random_state)
+        check_screw_axis(S)
+
+
+def test_conversions_between_screw_axis_and_exponential_coordinates():
+    S = np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+    theta = 1.0
+    Stheta = exponential_coordinates_from_screw_axis(S, theta)
+    S2, theta2 = screw_axis_from_exponential_coordinates(Stheta)
+    assert_array_almost_equal(S, S2)
+    assert_almost_equal(theta, theta2)
+
+    S = np.zeros(6)
+    theta = 0.0
+    Stheta = exponential_coordinates_from_screw_axis(S, theta)
+    S2, theta2 = screw_axis_from_exponential_coordinates(Stheta)
+    assert_array_almost_equal(S, S2)
+    assert_almost_equal(theta, theta2)
+
+    random_state = np.random.RandomState(33)
+    for _ in range(5):
+        S = random_screw_axis(random_state)
+        theta = random_state.rand()
+        Stheta = exponential_coordinates_from_screw_axis(S, theta)
+        S2, theta2 = screw_axis_from_exponential_coordinates(Stheta)
+        assert_array_almost_equal(S, S2)
+        assert_almost_equal(theta, theta2)

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -14,10 +14,13 @@ from pytransform3d.transformations import (random_transform, transform_from,
                                            check_screw_axis,
                                            check_exponential_coordinates,
                                            screw_axis_from_screw_parameters,
-                                           screw_parameters_from_screw_axis)
+                                           screw_parameters_from_screw_axis,
+                                           transform_from_exponential_coordinates,
+                                           exponential_coordinates_from_transform)
 from pytransform3d.rotations import (matrix_from, random_axis_angle,
                                      random_vector, axis_angle_from_matrix,
-                                     norm_vector, perpendicular_to_vector)
+                                     norm_vector, perpendicular_to_vector,
+                                     active_matrix_from_angle)
 from nose.tools import assert_equal, assert_almost_equal, assert_raises_regexp
 from numpy.testing import assert_array_almost_equal
 
@@ -349,3 +352,34 @@ def test_conversions_between_screw_axis_and_parameters():
         assert_array_almost_equal(q, q2)
         assert_array_almost_equal(s_axis, s_axis2)
         assert_array_almost_equal(h, h2)
+
+
+def test_conversions_between_exponential_coordinates_and_transform():
+    A2B = np.eye(4)
+    Stheta = exponential_coordinates_from_transform(A2B)
+    assert_array_almost_equal(Stheta, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    A2B2 = transform_from_exponential_coordinates(Stheta)
+    assert_array_almost_equal(A2B, A2B2)
+
+    A2B = translate_transform(np.eye(4), [1.0, 5.0, 0.0])
+    Stheta = exponential_coordinates_from_transform(A2B)
+    assert_array_almost_equal(Stheta, [0.0, 0.0, 0.0, 1.0, 5.0, 0.0])
+    A2B2 = transform_from_exponential_coordinates(Stheta)
+    assert_array_almost_equal(A2B, A2B2)
+
+    A2B = rotate_transform(np.eye(4), active_matrix_from_angle(2, 0.5 * np.pi))
+    Stheta = exponential_coordinates_from_transform(A2B)
+    assert_array_almost_equal(Stheta, [0.0, 0.0, 0.5 * np.pi, 0.0, 0.0, 0.0])
+    A2B2 = transform_from_exponential_coordinates(Stheta)
+    assert_array_almost_equal(A2B, A2B2)
+
+    random_state = np.random.RandomState(52)
+    for _ in range(5):
+        A2B = random_transform(random_state)
+        print(A2B)
+        Stheta = exponential_coordinates_from_transform(A2B)
+        print(Stheta)
+        A2B2 = transform_from_exponential_coordinates(Stheta)
+        print(A2B2)
+        print(np.round(A2B - A2B2, 4))
+        assert_array_almost_equal(A2B, A2B2)

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -11,7 +11,8 @@ from pytransform3d.transformations import (random_transform, transform_from,
                                            check_pq, pq_from_transform,
                                            transform_from_pq,
                                            check_screw_parameters,
-                                           check_screw_axis)
+                                           check_screw_axis,
+                                           check_exponential_coordinates)
 from pytransform3d.rotations import (matrix_from, random_axis_angle,
                                      random_vector, axis_angle_from_matrix,
                                      norm_vector)
@@ -305,3 +306,13 @@ def test_check_screw_axis():
     S_both = np.r_[omega, v]
     S = check_screw_axis(S_both)
     assert_array_almost_equal(S, S_both)
+
+
+def test_check_exponential_coordinates():
+    assert_raises_regexp(
+        ValueError, "Expected array-like with shape",
+        check_exponential_coordinates, [0])
+
+    Stheta = [0.0, 1.0, 2.0, -5.0, -2, 3]
+    Stheta2 = check_exponential_coordinates(Stheta)
+    assert_array_almost_equal(Stheta, Stheta2)

--- a/pytransform3d/test/test_urdf.py
+++ b/pytransform3d/test/test_urdf.py
@@ -864,6 +864,25 @@ def test_parse_material():
     assert_array_almost_equal(tm.visuals[0].color, np.array([0, 0, 0, 1]))
 
 
+def test_parse_material_without_name():
+    urdf = """
+    <?xml version="1.0"?>
+    <robot name="mmm">
+        <material/>
+        <link name="root">
+            <visual>
+                <geometry>
+                    <box size="0.758292 1.175997 0.8875"/>
+                    <material name="Black"/>
+                </geometry>
+            </visual>
+        </link>
+    </robot>
+    """
+    tm = UrdfTransformManager()
+    assert_raises(UrdfException, tm.load_urdf, urdf)
+
+
 def test_parse_material_without_color():
     urdf = """
     <?xml version="1.0"?>
@@ -882,6 +901,49 @@ def test_parse_material_without_color():
     tm = UrdfTransformManager()
     tm.load_urdf(urdf)
     assert_true(tm.visuals[0].color is None)
+
+
+def test_parse_material_without_rgba():
+    urdf = """
+    <?xml version="1.0"?>
+    <robot name="mmm">
+        <material name="Black">
+            <color/>
+        </material>
+        <link name="root">
+            <visual>
+                <geometry>
+                    <box size="0.758292 1.175997 0.8875"/>
+                    <material name="Black"/>
+                </geometry>
+            </visual>
+        </link>
+    </robot>
+    """
+    tm = UrdfTransformManager()
+    assert_raises(UrdfException, tm.load_urdf, urdf)
+
+
+def test_parse_material_with_two_colors():
+    urdf = """
+    <?xml version="1.0"?>
+    <robot name="mmm">
+        <material name="Black">
+            <color rgba="0.0 0.0 0.0 1.0"/>
+            <color rgba="0.0 0.0 0.0 1.0"/>
+        </material>
+        <link name="root">
+            <visual>
+                <geometry>
+                    <box size="0.758292 1.175997 0.8875"/>
+                    <material name="Black"/>
+                </geometry>
+            </visual>
+        </link>
+    </robot>
+    """
+    tm = UrdfTransformManager()
+    assert_raises(UrdfException, tm.load_urdf, urdf)
 
 
 def test_parse_material_local():

--- a/pytransform3d/transform_manager.py
+++ b/pytransform3d/transform_manager.py
@@ -1,5 +1,7 @@
-"""Manage compley chains of transformations."""
-import warnings
+"""Manage compley chains of transformations.
+
+See :doc:`transform_manager` for more information.
+"""
 import numpy as np
 import scipy.sparse as sp
 from scipy.sparse import csgraph

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -523,6 +523,9 @@ def assert_transform(A2B, *args, **kwargs):
 def check_screw_parameters(q, s_axis, h):
     """Input validation of screw parameters.
 
+    The parameters :math:`(\\boldsymbol{q}, \\hat{\\boldsymbol{s}}, h)` describe
+    a screw.
+
     Parameters
     ----------
     q : array-like, shape (3,)
@@ -537,11 +540,11 @@ def check_screw_parameters(q, s_axis, h):
 
     Returns
     -------
-    q : array-like, shape (3,)
+    q : array, shape (3,)
         Vector to a point on the screw axis. Will be set to zero vector when
         pitch is infinite (pure translation).
 
-    s_axis : array-like, shape (3,)
+    s_axis : array, shape (3,)
         Unit direction vector of the screw axis
 
     h : float
@@ -566,7 +569,16 @@ def check_screw_parameters(q, s_axis, h):
 
 
 def check_screw_axis(screw_axis):
-    """Input validation of screw parameters.
+    """Input validation of screw axis.
+
+    A screw axis
+
+    .. math::
+
+        \\mathcal{S} = \\left[\\begin{array}{c}\\boldsymbol{\\omega}\\\\\\boldsymbol{v}\\end{array}\\right] \in \\mathbb{R}^6
+
+    consists of a part that describes rotation and a part that describes
+    translation.
 
     Parameters
     ----------
@@ -578,7 +590,7 @@ def check_screw_axis(screw_axis):
 
     Returns
     -------
-    screw_axis : array-like, shape (6,)
+    screw_axis : array, shape (6,)
         Screw axis described by 6 values
         (omega_1, omega_2, omega_3, v_1, v_2, v_3),
         where the first 3 components are related to rotation and the last 3
@@ -608,6 +620,10 @@ def check_screw_axis(screw_axis):
 def check_exponential_coordinates(Stheta):
     """Input validation for exponential coordinates of transformation.
 
+    Exponential coordinates of a transformation :math:`\\mathcal{S}\\theta
+    \\in \\mathbb{R}^6` are the product of a screw axis and a scalar
+    :math:`\\theta`.
+
     Parameters
     ----------
     Stheta : array-like, shape (6,)
@@ -621,7 +637,7 @@ def check_exponential_coordinates(Stheta):
 
     Returns
     -------
-    Stheta : array-like, shape (6,)
+    Stheta : array, shape (6,)
         Exponential coordinates of transformation:
         S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
         where the first 3 components are related to rotation and the last 3
@@ -640,6 +656,28 @@ def check_exponential_coordinates(Stheta):
 def check_unit_twist(unit_twist, tolerance=1e-6, strict_check=True):
     """Input validation for unit twist.
 
+    A unit twist matrix consists of the cross-product matrix of a rotation
+    axis and a translation.
+
+    .. math::
+
+        \\left[\\mathcal S\\right]
+        =
+        \\left( \\begin{array}{cc}
+            \\left[\\boldsymbol{\\omega}\\right] & \\boldsymbol v\\\\
+            \\boldsymbol 0 & 0\\\\
+        \\end{array} \\right)
+        =
+        \\left(
+        \\begin{matrix}
+        0 & -\\omega_3 & \\omega_2 & v_1\\\\
+        \\omega_3 & 0 & -\\omega_1 & v_2\\\\
+        -\\omega_2 & \\omega_1 & 0 & v_3\\\\
+        0 & 0 & 0 & 0\\\\
+        \\end{matrix}
+        \\right)
+        \\in \\mathbb{R}^{4 \\times 4}
+
     Parameters
     ----------
     unit_twist : array-like, shape (4, 4)
@@ -655,7 +693,7 @@ def check_unit_twist(unit_twist, tolerance=1e-6, strict_check=True):
 
     Returns
     -------
-    unit_twist : array-like, shape (4, 4)
+    unit_twist : array, shape (4, 4)
         A unit twist consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
     """
@@ -691,9 +729,13 @@ def check_unit_twist(unit_twist, tolerance=1e-6, strict_check=True):
 def check_transform_log(transform_log, tolerance=1e-6, strict_check=True):
     """Input validation for logarithm of transformation.
 
+    The logarithm of a transformation :math:`\\left[\\mathcal{S}\\right]\\theta
+    \\in \\mathbb{R}^{4 \\times 4}` are the product of a unit twist and a
+    scalar :math:`\\theta`.
+
     Parameters
     ----------
-    transform_log : array, shape (4, 4)
+    transform_log : array-like, shape (4, 4)
         Matrix logarithm of transformation matrix: [S] * theta.
 
     tolerance : float, optional (default: 1e-6)
@@ -736,7 +778,7 @@ def random_screw_axis(random_state=np.random.RandomState(0)):
 
     Returns
     -------
-    screw_axis : array-like, shape (6,)
+    screw_axis : array, shape (6,)
         Screw axis described by 6 values
         (omega_1, omega_2, omega_3, v_1, v_2, v_3),
         where the first 3 components are related to rotation and the last 3
@@ -763,10 +805,10 @@ def screw_parameters_from_screw_axis(screw_axis):
 
     Returns
     -------
-    q : array-like, shape (3,)
+    q : array, shape (3,)
         Vector to a point on the screw axis that is orthogonal to s_axis
 
-    s_axis : array-like, shape (3,)
+    s_axis : array, shape (3,)
         Unit direction vector of the screw axis
 
     h : float
@@ -838,7 +880,7 @@ def screw_axis_from_exponential_coordinates(Stheta):
 
     Returns
     -------
-    screw_axis : array-like, shape (6,)
+    screw_axis : array, shape (6,)
         Screw axis described by 6 values
         (omega_1, omega_2, omega_3, v_1, v_2, v_3),
         where the first 3 components are related to rotation and the last 3
@@ -871,7 +913,7 @@ def screw_axis_from_unit_twist(unit_twist):
 
     Returns
     -------
-    screw_axis : array-like, shape (6,)
+    screw_axis : array, shape (6,)
         Screw axis described by 6 values
         (omega_1, omega_2, omega_3, v_1, v_2, v_3),
         where the first 3 components are related to rotation and the last 3
@@ -904,7 +946,7 @@ def exponential_coordinates_from_screw_axis(screw_axis, theta):
 
     Returns
     -------
-    Stheta : array-like, shape (6,)
+    Stheta : array, shape (6,)
         Exponential coordinates of transformation:
         S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
         where the first 3 components are related to rotation and the last 3
@@ -913,6 +955,7 @@ def exponential_coordinates_from_screw_axis(screw_axis, theta):
         will be represented by a negative screw axis instead. This is relevant
         if you want to recover theta from exponential coordinates.
     """
+    screw_axis = check_screw_axis(screw_axis)
     return screw_axis * theta
 
 
@@ -921,12 +964,12 @@ def exponential_coordinates_from_transform_log(transform_log):
 
     Parameters
     ----------
-    transform_log : array, shape (4, 4)
+    transform_log : array-like, shape (4, 4)
         Matrix logarithm of transformation matrix: [S] * theta.
 
     Returns
     -------
-    Stheta : array-like, shape (6,)
+    Stheta : array, shape (6,)
         Exponential coordinates of transformation:
         S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
         where S is the screw axis, the first 3 components are related to
@@ -960,7 +1003,7 @@ def exponential_coordinates_from_transform(A2B, strict_check=True):
 
     Returns
     -------
-    Stheta : array-like, shape (6,)
+    Stheta : array, shape (6,)
         Exponential coordinates of transformation:
         S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
         where S is the screw axis, the first 3 components are related to
@@ -1001,7 +1044,7 @@ def unit_twist_from_screw_axis(screw_axis):
 
     Returns
     -------
-    unit_twist : array-like, shape (4, 4)
+    unit_twist : array, shape (4, 4)
         A unit twist consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
     """
@@ -1020,12 +1063,12 @@ def unit_twist_from_transform_log(transform_log):
 
     Parameters
     ----------
-    transform_log : array, shape (4, 4)
+    transform_log : array-like, shape (4, 4)
         Matrix logarithm of transformation matrix: [S] * theta.
 
     Returns
     -------
-    unit_twist : array-like, shape (4, 4)
+    unit_twist : array, shape (4, 4)
         A unit twist consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
     """
@@ -1183,7 +1226,7 @@ def transform_from_transform_log(transform_log):
 
     Parameters
     ----------
-    transform_log : array, shape (4, 4)
+    transform_log : array-like, shape (4, 4)
         Matrix logarithm of transformation matrix: [S] * theta.
 
     Returns

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -617,7 +617,7 @@ def check_exponential_coordinates(Stheta):
     """
     Stheta = np.asarray(Stheta, dtype=np.float)
     if Stheta.ndim != 1 or Stheta.shape[0] != 6:
-        raise ValueError("Expected 3D vector with shape (6,), got array-like "
+        raise ValueError("Expected array-like with shape (6,), got array-like "
                          "object with shape %s" % (Stheta.shape,))
     return Stheta
 

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -516,7 +516,7 @@ def assert_transform(A2B, *args, **kwargs):
                               *args, **kwargs)
 
 
-def screw_axis_from_screw_parameters(q, s_axis, h, theta=1.0):
+def screw_axis_from_screw_parameters(q, s_axis, h):
     """TODO
 
     Parameters
@@ -530,7 +530,7 @@ def screw_axis_from_screw_parameters(q, s_axis, h, theta=1.0):
     if np.isinf(h):
         raise NotImplementedError("TODO only translation")
     else:
-        return np.r_[s_axis, np.cross(q, s_axis) + h * s_axis] * theta
+        return np.r_[s_axis, np.cross(q, s_axis) + h * s_axis]
 
 
 def transform_from_exponential_coordinates(Stheta):

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -835,7 +835,7 @@ def transform_log_from_transform(A2B, strict_check=True):
     R = A2B[:3, :3]
     p = A2B[:3, 3]
 
-    transform_log = np.zeroy((4, 4))
+    transform_log = np.zeros((4, 4))
 
     if np.linalg.norm(np.eye(3) - R) < np.finfo(float).eps:
         transform_log[:3, 3] = p
@@ -915,11 +915,10 @@ def transform_from_transform_log(transform_log):
     A2B = np.eye(4)
     A2B[:3, :3] = matrix_from_axis_angle(np.r_[omega_unit, theta])
     omega_unit_matrix = transform_log[:3, :3] / theta
-    A2B[:3, 3] = np.dot(
-        np.eye(3) * theta
-        + (1.0 - math.cos(theta)) * omega_unit_matrix
-        + (theta - math.sin(theta)) * np.dot(omega_unit_matrix, omega_unit_matrix),
-        v)
+    G = (np.eye(3) * theta
+         + (1.0 - math.cos(theta)) * omega_unit_matrix
+         + (theta - math.sin(theta)) * np.dot(omega_unit_matrix, omega_unit_matrix))
+    A2B[:3, 3] = np.dot(G, v)
     return A2B
 
 

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -727,13 +727,13 @@ def exponential_coordinates_from_screw_axis(screw_axis, theta):
     return screw_axis * theta
 
 
-def exponential_coordinates_from_matrix_log(matrix_log):
+def exponential_coordinates_from_transform_log(transform_log):
     # TODO check matrix log
     Stheta = np.empty(6)
-    Stheta[0] = matrix_log[2, 1]
-    Stheta[1] = matrix_log[0, 2]
-    Stheta[2] = matrix_log[1, 0]
-    Stheta[3:] = matrix_log[:3, 3]
+    Stheta[0] = transform_log[2, 1]
+    Stheta[1] = transform_log[0, 2]
+    Stheta[2] = transform_log[1, 0]
+    Stheta[3:] = transform_log[:3, 3]
     return Stheta
 
 
@@ -792,19 +792,19 @@ def unit_twist_from_screw_axis(screw_axis):
     raise unit_twist
 
 
-def unit_twist_from_matrix_log(matrix_log):
+def unit_twist_from_transform_log(transform_log):
     raise NotImplementedError("TODO")
 
 
-def matrix_log_from_exponential_coordinates(Stheta):
+def transform_log_from_exponential_coordinates(Stheta):
     raise NotImplementedError("TODO")
 
 
-def matrix_log_from_unit_twist(unit_twist):
+def transform_log_from_unit_twist(unit_twist):
     raise NotImplementedError("TODO")
 
 
-def matrix_log_from_transform(A2B):
+def transform_log_from_transform(A2B):
     raise NotImplementedError("TODO")
 
 
@@ -849,7 +849,7 @@ def transform_from_exponential_coordinates(Stheta):
     return A2B
 
 
-def transform_from_matrix_log(matrix_log):
+def transform_from_transform_log(transform_log):
     raise NotImplementedError("TODO")
 
 

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -609,9 +609,9 @@ def check_exponential_coordinates(Stheta):
     Stheta : array-like, shape (6,)
         Exponential coordinates of transformation:
         S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
-        where the first 3 components are related to rotation and the last 3
-        components are related to translation. Theta is the rotation angle
-        and h * theta the translation.
+        where S is the screw axis, the first 3 components are related to
+        rotation and the last 3 components are related to translation.
+        Theta is the rotation angle and h * theta the translation.
 
     Returns
     -------
@@ -620,7 +620,9 @@ def check_exponential_coordinates(Stheta):
         S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
         where the first 3 components are related to rotation and the last 3
         components are related to translation. Theta is the rotation angle
-        and h * theta the translation.
+        and h * theta the translation. Theta should be >= 0. Negative rotations
+        will be represented by a negative screw axis instead. This is relevant
+        if you want to recover theta from exponential coordinates.
     """
     Stheta = np.asarray(Stheta, dtype=np.float)
     if Stheta.ndim != 1 or Stheta.shape[0] != 6:
@@ -766,9 +768,9 @@ def exponential_coordinates_from_transform(A2B, strict_check=True):
     Stheta : array-like, shape (6,)
         Exponential coordinates of transformation:
         S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
-        where the first 3 components are related to rotation and the last 3
-        components are related to translation. Theta is the rotation angle
-        and h * theta the translation.
+        where S is the screw axis, the first 3 components are related to
+        rotation and the last 3 components are related to translation.
+        Theta is the rotation angle and h * theta the translation.
     """
     A2B = check_transform(A2B, strict_check=strict_check)
 
@@ -798,7 +800,7 @@ def unit_twist_from_screw_axis(screw_axis):
     unit_twist = np.zeros((4, 4))
     unit_twist[:3, :3] = cross_product_matrix(omega)
     unit_twist[:3, 3] = v
-    raise unit_twist
+    return unit_twist
 
 
 def unit_twist_from_transform_log(transform_log):
@@ -808,7 +810,9 @@ def unit_twist_from_transform_log(transform_log):
     theta = np.linalg.norm(omega)
     if abs(theta) < np.finfo(float).eps:
         theta = np.linalg.norm(transform_log[:3, 3])
-    return transform_log / theta
+    if abs(theta) < np.finfo(float).eps:
+        return np.zeros((4, 4)), 0.0
+    return transform_log / theta, theta
 
 
 def transform_log_from_exponential_coordinates(Stheta):
@@ -864,9 +868,9 @@ def transform_from_exponential_coordinates(Stheta):
     Stheta : array-like, shape (6,)
         Exponential coordinates of transformation:
         S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
-        where the first 3 components are related to rotation and the last 3
-        components are related to translation. Theta is the rotation angle
-        and h * theta the translation.
+        where S is the screw axis, the first 3 components are related to
+        rotation and the last 3 components are related to translation.
+        Theta is the rotation angle and h * theta the translation.
 
     Returns
     -------

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -811,6 +811,22 @@ def screw_axis_from_exponential_coordinates(Stheta):
 
 
 def screw_axis_from_unit_twist(unit_twist):
+    """Compute screw axis from unit twist.
+
+    Parameters
+    ----------
+    unit_twist : array-like, shape (4, 4)
+        A unit twist consists of a cross-product matrix that represents an
+        axis of rotation, a translation, and a row of zeros.
+
+    Returns
+    -------
+    screw_axis : array-like, shape (6,)
+        Screw axis described by 6 values
+        (omega_1, omega_2, omega_3, v_1, v_2, v_3),
+        where the first 3 components are related to rotation and the last 3
+        components are related to translation.
+    """
     unit_twist = check_unit_twist(unit_twist)
     screw_axis = np.empty(6)
     screw_axis[0] = unit_twist[2, 1]
@@ -850,6 +866,22 @@ def exponential_coordinates_from_screw_axis(screw_axis, theta):
 
 
 def exponential_coordinates_from_transform_log(transform_log):
+    """Compute exponential coordinates from logarithm of transformation.
+
+    Parameters
+    ----------
+    transform_log : array, shape (4, 4)
+        Matrix logarithm of transformation matrix: [S] * theta.
+
+    Returns
+    -------
+    Stheta : array-like, shape (6,)
+        Exponential coordinates of transformation:
+        S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
+        where S is the screw axis, the first 3 components are related to
+        rotation and the last 3 components are related to translation.
+        Theta is the rotation angle and h * theta the translation.
+    """
     # TODO check matrix log
     Stheta = np.empty(6)
     Stheta[0] = transform_log[2, 1]
@@ -905,6 +937,22 @@ def exponential_coordinates_from_transform(A2B, strict_check=True):
 
 
 def unit_twist_from_screw_axis(screw_axis):
+    """Compute unit twist from screw axis.
+
+    Parameters
+    ----------
+    screw_axis : array-like, shape (6,)
+        Screw axis described by 6 values
+        (omega_1, omega_2, omega_3, v_1, v_2, v_3),
+        where the first 3 components are related to rotation and the last 3
+        components are related to translation.
+
+    Returns
+    -------
+    unit_twist : array-like, shape (4, 4)
+        A unit twist consists of a cross-product matrix that represents an
+        axis of rotation, a translation, and a row of zeros.
+    """
     screw_axis = check_screw_axis(screw_axis)
     omega = screw_axis[:3]
     v = screw_axis[3:]
@@ -915,6 +963,19 @@ def unit_twist_from_screw_axis(screw_axis):
 
 
 def unit_twist_from_transform_log(transform_log):
+    """Compute unit twist from logarithm of transformation.
+
+    Parameters
+    ----------
+    transform_log : array, shape (4, 4)
+        Matrix logarithm of transformation matrix: [S] * theta.
+
+    Returns
+    -------
+    unit_twist : array-like, shape (4, 4)
+        A unit twist consists of a cross-product matrix that represents an
+        axis of rotation, a translation, and a row of zeros.
+    """
     # TODO check transform_log
     omega = np.array([
         transform_log[2, 1], transform_log[0, 2], transform_log[1, 0]])
@@ -927,6 +988,22 @@ def unit_twist_from_transform_log(transform_log):
 
 
 def transform_log_from_exponential_coordinates(Stheta):
+    """Compute matrix logarithm of transformation from exponential coordinates.
+
+    Parameters
+    ----------
+    Stheta : array-like, shape (6,)
+        Exponential coordinates of transformation:
+        S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
+        where S is the screw axis, the first 3 components are related to
+        rotation and the last 3 components are related to translation.
+        Theta is the rotation angle and h * theta the translation.
+
+    Returns
+    -------
+    transform_log : array, shape (4, 4)
+        Matrix logarithm of transformation matrix: [S] * theta.
+    """
     check_exponential_coordinates(Stheta)
     omega = Stheta[:3]
     v = Stheta[3:]
@@ -937,11 +1014,45 @@ def transform_log_from_exponential_coordinates(Stheta):
 
 
 def transform_log_from_unit_twist(unit_twist, theta):
+    """Compute matrix logarithm of transformation from unit twist and theta.
+
+    Parameters
+    ----------
+    unit_twist : array-like, shape (4, 4)
+        A unit twist consists of a cross-product matrix that represents an
+        axis of rotation, a translation, and a row of zeros.
+
+    theta : float
+        Parameter of the transformation: theta is the angle of rotation
+        and h * theta the translation.
+
+    Returns
+    -------
+    transform_log : array, shape (4, 4)
+        Matrix logarithm of transformation matrix: [S] * theta.
+    """
     unit_twist = check_unit_twist(unit_twist)
     return unit_twist * theta
 
 
 def transform_log_from_transform(A2B, strict_check=True):
+    """Compute matrix logarithm of transformation from transformation.
+
+    Parameters
+    ----------
+    A2B : array, shape (4, 4)
+        Transform from frame A to frame B
+
+    strict_check : bool, optional (default: True)
+        Raise a ValueError if the transformation matrix is not numerically
+        close enough to a real transformation matrix. Otherwise we print a
+        warning.
+
+    Returns
+    -------
+    transform_log : array, shape (4, 4)
+        Matrix logarithm of transformation matrix: [S] * theta.
+    """
     A2B = check_transform(A2B, strict_check=strict_check)
 
     R = A2B[:3, :3]
@@ -1012,6 +1123,18 @@ def transform_from_exponential_coordinates(Stheta):
 
 
 def transform_from_transform_log(transform_log):
+    """Compute transformation from matrix logarithm of transformation.
+
+    Parameters
+    ----------
+    transform_log : array, shape (4, 4)
+        Matrix logarithm of transformation matrix: [S] * theta.
+
+    Returns
+    -------
+    A2B : array, shape (4, 4)
+        Transform from frame A to frame B
+    """
     # TODO check transform_log
     omega_theta = np.array([
         transform_log[2, 1], transform_log[0, 2], transform_log[1, 0]])

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -6,7 +6,8 @@ from .rotations import (random_quaternion, random_vector,
                         matrix_from_quaternion, quaternion_from_matrix,
                         assert_rotation_matrix, check_matrix,
                         norm_vector, axis_angle_from_matrix,
-                        matrix_from_axis_angle, cross_product_matrix)
+                        matrix_from_axis_angle, cross_product_matrix,
+                        check_skew_symmetric_matrix)
 from numpy.testing import assert_array_almost_equal
 
 
@@ -633,7 +634,7 @@ def check_exponential_coordinates(Stheta):
     return Stheta
 
 
-def check_unit_twist(unit_twist):
+def check_unit_twist(unit_twist, tolerance=1e-6, strict_check=True):
     """Input validation for unit twist.
 
     Parameters
@@ -641,6 +642,13 @@ def check_unit_twist(unit_twist):
     unit_twist : array-like, shape (4, 4)
         A unit twist consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
+
+    tolerance : float, optional (default: 1e-6)
+        Tolerance threshold for checks.
+
+    strict_check : bool, optional (default: True)
+        Raise a ValueError if [omega].T is not numerically close enough to
+        -[omega]. Otherwise we print a warning.
 
     Returns
     -------
@@ -655,6 +663,8 @@ def check_unit_twist(unit_twist):
                          "object with shape %s" % (unit_twist.shape,))
     if any(unit_twist[3] != 0.0):
         raise ValueError("Last row of unit twist must only contains zeros.")
+
+    check_skew_symmetric_matrix(unit_twist[:3, :3], tolerance, strict_check)
 
     omega_norm = np.linalg.norm(
         [unit_twist[2, 1], unit_twist[0, 2], unit_twist[1, 0]])
@@ -675,13 +685,20 @@ def check_unit_twist(unit_twist):
     return unit_twist
 
 
-def check_transform_log(transform_log):
+def check_transform_log(transform_log, tolerance=1e-6, strict_check=True):
     """Input validation for logarithm of transformation.
 
     Parameters
     ----------
     transform_log : array, shape (4, 4)
         Matrix logarithm of transformation matrix: [S] * theta.
+
+    tolerance : float, optional (default: 1e-6)
+        Tolerance threshold for checks.
+
+    strict_check : bool, optional (default: True)
+        Raise a ValueError if [omega].T is not numerically close enough to
+        -[omega]. Otherwise we print a warning.
 
     Returns
     -------
@@ -697,6 +714,9 @@ def check_transform_log(transform_log):
         raise ValueError(
             "Last row of logarithm of transformation must only "
             "contains zeros.")
+
+    check_skew_symmetric_matrix(transform_log[:3, :3], tolerance, strict_check)
+
     return transform_log
 
 

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -424,12 +424,12 @@ def scale_transform(A2B, s_xr=1.0, s_yr=1.0, s_zr=1.0, s_r=1.0,
 
 
 def pq_from_transform(A2B, strict_check=True):
-    """Conversion from homogeneous matrix to position and quaternion.
+    """Compute position and quaternion from transformation matrix.
 
     Parameters
     ----------
     A2B : array-like, shape (4, 4)
-        Transform from frame A to frame B
+        Transformation matrix from frame A to frame B
 
     strict_check : bool, optional (default: True)
         Raise a ValueError if the transformation matrix is not numerically
@@ -446,7 +446,7 @@ def pq_from_transform(A2B, strict_check=True):
 
 
 def transform_from_pq(pq):
-    """Conversion from position and quaternion to homogeneous matrix.
+    """Compute transformation matrix from position and quaternion.
 
     Parameters
     ----------
@@ -456,7 +456,7 @@ def transform_from_pq(pq):
     Returns
     -------
     A2B : array-like, shape (4, 4)
-        Transform from frame A to frame B
+        Transformation matrix from frame A to frame B
     """
     pq = check_pq(pq)
     return transform_from(matrix_from_quaternion(pq[3:]), pq[:3])
@@ -987,14 +987,14 @@ def exponential_coordinates_from_transform_log(transform_log):
 
 
 def exponential_coordinates_from_transform(A2B, strict_check=True):
-    """Conversion from homogeneous matrix to exponential coordinates.
+    """Compute exponential coordinates from transformation matrix.
 
     Logarithmic map.
 
     Parameters
     ----------
     A2B : array-like, shape (4, 4)
-        Transform from frame A to frame B
+        Transformation matrix from frame A to frame B
 
     strict_check : bool, optional (default: True)
         Raise a ValueError if the transformation matrix is not numerically
@@ -1180,7 +1180,7 @@ def transform_log_from_transform(A2B, strict_check=True):
 
 
 def transform_from_exponential_coordinates(Stheta):
-    """Conversion from exponential coordinates to homogeneous matrix.
+    """Compute transformation matrix from exponential coordinates.
 
     Exponential map.
 
@@ -1196,7 +1196,7 @@ def transform_from_exponential_coordinates(Stheta):
     Returns
     -------
     A2B : array, shape (4, 4)
-        Transform from frame A to frame B
+        Transformation matrix from frame A to frame B
     """
     Stheta = check_exponential_coordinates(Stheta)
 
@@ -1258,7 +1258,7 @@ def transform_from_transform_log(transform_log):
 
 
 def plot_screw(ax=None, q=np.zeros(3), s_axis=np.array([1.0, 0.0, 0.0]), h=1.0, theta=1.0, A2B=None, s=1.0, ax_s=1, alpha=1.0, **kwargs):
-    """Plot screw axis and transformation.
+    """Plot transformation about and along screw axis.
 
     Parameters
     ----------

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -675,6 +675,31 @@ def check_unit_twist(unit_twist):
     return unit_twist
 
 
+def check_transform_log(transform_log):
+    """Input validation for logarithm of transformation.
+
+    Parameters
+    ----------
+    transform_log : array, shape (4, 4)
+        Matrix logarithm of transformation matrix: [S] * theta.
+
+    Returns
+    -------
+    transform_log : array, shape (4, 4)
+        Matrix logarithm of transformation matrix: [S] * theta.
+    """
+    transform_log = np.asarray(transform_log, dtype=np.float)
+    if (transform_log.ndim != 2 or transform_log.shape[0] != 4
+            or transform_log.shape[1] != 4):
+        raise ValueError("Expected array-like with shape (4, 4), got array-like "
+                         "object with shape %s" % (transform_log.shape,))
+    if any(transform_log[3] != 0.0):
+        raise ValueError(
+            "Last row of logarithm of transformation must only "
+            "contains zeros.")
+    return transform_log
+
+
 def random_screw_axis(random_state=np.random.RandomState(0)):
     """Generate random screw axis.
 
@@ -767,6 +792,7 @@ def screw_axis_from_screw_parameters(q, s_axis, h):
         components are related to translation.
     """
     q, s_axis, h = check_screw_parameters(q, s_axis, h)
+
     if np.isinf(h):  # pure translation
         return np.r_[0.0, 0.0, 0.0, s_axis]
     else:
@@ -800,6 +826,7 @@ def screw_axis_from_exponential_coordinates(Stheta):
         and h * theta the translation.
     """
     Stheta = check_exponential_coordinates(Stheta)
+
     omega_theta = Stheta[:3]
     v_theta = Stheta[3:]
     theta = np.linalg.norm(omega_theta)
@@ -828,6 +855,7 @@ def screw_axis_from_unit_twist(unit_twist):
         components are related to translation.
     """
     unit_twist = check_unit_twist(unit_twist)
+
     screw_axis = np.empty(6)
     screw_axis[0] = unit_twist[2, 1]
     screw_axis[1] = unit_twist[0, 2]
@@ -882,7 +910,8 @@ def exponential_coordinates_from_transform_log(transform_log):
         rotation and the last 3 components are related to translation.
         Theta is the rotation angle and h * theta the translation.
     """
-    # TODO check matrix log
+    transform_log = check_transform_log(transform_log)
+
     Stheta = np.empty(6)
     Stheta[0] = transform_log[2, 1]
     Stheta[1] = transform_log[0, 2]
@@ -954,6 +983,7 @@ def unit_twist_from_screw_axis(screw_axis):
         axis of rotation, a translation, and a row of zeros.
     """
     screw_axis = check_screw_axis(screw_axis)
+
     omega = screw_axis[:3]
     v = screw_axis[3:]
     unit_twist = np.zeros((4, 4))
@@ -976,7 +1006,8 @@ def unit_twist_from_transform_log(transform_log):
         A unit twist consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
     """
-    # TODO check transform_log
+    transform_log = check_transform_log(transform_log)
+
     omega = np.array([
         transform_log[2, 1], transform_log[0, 2], transform_log[1, 0]])
     theta = np.linalg.norm(omega)
@@ -1005,6 +1036,7 @@ def transform_log_from_exponential_coordinates(Stheta):
         Matrix logarithm of transformation matrix: [S] * theta.
     """
     check_exponential_coordinates(Stheta)
+
     omega = Stheta[:3]
     v = Stheta[3:]
     transform_log = np.zeros((4, 4))
@@ -1101,6 +1133,7 @@ def transform_from_exponential_coordinates(Stheta):
         Transform from frame A to frame B
     """
     Stheta = check_exponential_coordinates(Stheta)
+
     omega_theta = Stheta[:3]
     theta = np.linalg.norm(omega_theta)
 
@@ -1135,7 +1168,8 @@ def transform_from_transform_log(transform_log):
     A2B : array, shape (4, 4)
         Transform from frame A to frame B
     """
-    # TODO check transform_log
+    transform_log = check_transform_log(transform_log)
+
     omega_theta = np.array([
         transform_log[2, 1], transform_log[0, 2], transform_log[1, 0]])
     v = transform_log[:3, 3]

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -1,4 +1,7 @@
-"""Transformations in three dimensions - SE(3)."""
+"""Transformations in three dimensions - SE(3).
+
+See :doc:`transformations` for more information.
+"""
 import warnings
 import math
 import numpy as np

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -699,7 +699,7 @@ def screw_parameters_from_screw_axis(screw_axis):
 
 
 def transform_from_exponential_coordinates(Stheta):
-    """Conversion from twist displacement to homogeneous matrix.
+    """Conversion from exponential coordinates to homogeneous matrix.
 
     Exponential map.
 
@@ -714,7 +714,7 @@ def transform_from_exponential_coordinates(Stheta):
 
     Returns
     -------
-    A2B : array-like, shape (4, 4)
+    A2B : array, shape (4, 4)
         Transform from frame A to frame B
     """
     Stheta = check_exponential_coordinates(Stheta)
@@ -737,6 +737,28 @@ def transform_from_exponential_coordinates(Stheta):
         + (theta - math.sin(theta)) * np.dot(omega_matrix, omega_matrix),
         v)
     return A2B
+
+
+def exponential_coordinates_from_transform(A2B):
+    """Conversion from homogeneous matrix to exponential coordinates.
+
+    Logarithmic map.
+
+    Parameters
+    ----------
+    A2B : array-like, shape (4, 4)
+        Transform from frame A to frame B
+
+    Returns
+    -------
+    Stheta : array-like, shape (6,)
+        Exponential coordinates of transformation:
+        S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
+        where the first 3 components are related to rotation and the last 3
+        components are related to translation. Theta is the rotation angle
+        and h * theta the translation.
+    """
+    raise NotImplementedError()
 
 
 def plot_screw(ax=None, q=np.zeros(3), s_axis=np.array([1.0, 0.0, 0.0]), h=1.0, theta=1.0, A2B=None, s=1.0, ax_s=1, alpha=1.0, **kwargs):

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -94,7 +94,7 @@ def transform_from(R, p, strict_check=True):
 
 
 def random_transform(random_state=np.random.RandomState(0)):
-    """Generate an random transform.
+    """Generate random transform.
 
     Each component of the translation will be sampled from
     :math:`\mathcal{N}(\mu=0, \sigma=1)`.
@@ -609,9 +609,11 @@ def check_exponential_coordinates(Stheta):
     Stheta : array-like, shape (6,)
         Exponential coordinates of transformation:
         S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
-        where S is the screw axis, the first 3 components are related to
-        rotation and the last 3 components are related to translation.
-        Theta is the rotation angle and h * theta the translation.
+        where the first 3 components are related to rotation and the last 3
+        components are related to translation. Theta is the rotation angle
+        and h * theta the translation. Theta should be >= 0. Negative rotations
+        will be represented by a negative screw axis instead. This is relevant
+        if you want to recover theta from exponential coordinates.
 
     Returns
     -------
@@ -632,7 +634,24 @@ def check_exponential_coordinates(Stheta):
 
 
 def random_screw_axis(random_state=np.random.RandomState(0)):
-    """TODO"""
+    """Generate random screw axis.
+
+    Each component of v will be sampled from
+    :math:`\mathcal{N}(\mu=0, \sigma=1)`.
+
+    Parameters
+    ----------
+    random_state : np.random.RandomState, optional (default: random seed 0)
+        Random number generator
+
+    Returns
+    -------
+    screw_axis : array-like, shape (6,)
+        Screw axis described by 6 values
+        (omega_1, omega_2, omega_3, v_1, v_2, v_3),
+        where the first 3 components are related to rotation and the last 3
+        components are related to translation.
+    """
     omega = norm_vector(random_state.randn(3))
     v = random_state.randn(3)
     return np.hstack((omega, v))
@@ -713,6 +732,31 @@ def screw_axis_from_screw_parameters(q, s_axis, h):
 
 
 def screw_axis_from_exponential_coordinates(Stheta):
+    """Compute screw axis and theta from exponential coordinates.
+
+    Parameters
+    ----------
+    Stheta : array-like, shape (6,)
+        Exponential coordinates of transformation:
+        S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
+        where the first 3 components are related to rotation and the last 3
+        components are related to translation. Theta is the rotation angle
+        and h * theta the translation. Theta should be >= 0. Negative rotations
+        will be represented by a negative screw axis instead. This is relevant
+        if you want to recover theta from exponential coordinates.
+
+    Returns
+    -------
+    screw_axis : array-like, shape (6,)
+        Screw axis described by 6 values
+        (omega_1, omega_2, omega_3, v_1, v_2, v_3),
+        where the first 3 components are related to rotation and the last 3
+        components are related to translation.
+
+    theta : float
+        Parameter of the transformation: theta is the angle of rotation
+        and h * theta the translation.
+    """
     Stheta = check_exponential_coordinates(Stheta)
     omega_theta = Stheta[:3]
     v_theta = Stheta[3:]
@@ -735,6 +779,31 @@ def screw_axis_from_unit_twist(unit_twist):
 
 
 def exponential_coordinates_from_screw_axis(screw_axis, theta):
+    """Compute exponential coordinates from screw axis and theta.
+
+    Parameters
+    ----------
+    screw_axis : array-like, shape (6,)
+        Screw axis described by 6 values
+        (omega_1, omega_2, omega_3, v_1, v_2, v_3),
+        where the first 3 components are related to rotation and the last 3
+        components are related to translation.
+
+    theta : float
+        Parameter of the transformation: theta is the angle of rotation
+        and h * theta the translation.
+
+    Returns
+    -------
+    Stheta : array-like, shape (6,)
+        Exponential coordinates of transformation:
+        S * theta = (omega_1, omega_2, omega_3, v_1, v_2, v_3) * theta,
+        where the first 3 components are related to rotation and the last 3
+        components are related to translation. Theta is the rotation angle
+        and h * theta the translation. Theta should be >= 0. Negative rotations
+        will be represented by a negative screw axis instead. This is relevant
+        if you want to recover theta from exponential coordinates.
+    """
     return screw_axis * theta
 
 

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -704,19 +704,37 @@ def screw_axis_from_screw_parameters(q, s_axis, h):
 
 
 def screw_axis_from_exponential_coordinates(Stheta):
-    raise NotImplementedError("TODO")
+    Stheta = check_exponential_coordinates(Stheta)
+    omega_theta = Stheta[:3]
+    v_theta = Stheta[3:]
+    theta = np.linalg.norm(omega_theta)
+    if theta == 0.0:
+        theta = np.linalg.norm(v_theta)
+    return Stheta / theta
 
 
 def screw_axis_from_unit_twist(unit_twist):
-    raise NotImplementedError("TODO")
+    # TODO check unit twist
+    screw_axis = np.empty(6)
+    screw_axis[0] = unit_twist[2, 1]
+    screw_axis[1] = unit_twist[0, 2]
+    screw_axis[2] = unit_twist[1, 0]
+    screw_axis[3:] = unit_twist[:3, 3]
+    return screw_axis
 
 
 def exponential_coordinates_from_screw_axis(screw_axis, theta):
-    raise NotImplementedError("TODO")
+    return screw_axis * theta
 
 
 def exponential_coordinates_from_matrix_log(matrix_log):
-    raise NotImplementedError("TODO")
+    # TODO check matrix log
+    Stheta = np.empty(6)
+    Stheta[0] = matrix_log[2, 1]
+    Stheta[1] = matrix_log[0, 2]
+    Stheta[2] = matrix_log[1, 0]
+    Stheta[3:] = matrix_log[:3, 3]
+    return Stheta
 
 
 def exponential_coordinates_from_transform(A2B, strict_check=True):
@@ -765,7 +783,13 @@ def exponential_coordinates_from_transform(A2B, strict_check=True):
 
 
 def unit_twist_from_screw_axis(screw_axis):
-    raise NotImplementedError("TODO")
+    screw_axis = check_screw_axis(screw_axis)
+    omega = screw_axis[:3]
+    v = screw_axis[3:]
+    unit_twist = np.zeros((4, 4))
+    unit_twist[:3, :3] = cross_product_matrix(omega)
+    unit_twist[:3, 3] = v
+    raise unit_twist
 
 
 def unit_twist_from_matrix_log(matrix_log):

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -653,10 +653,10 @@ def check_exponential_coordinates(Stheta):
     return Stheta
 
 
-def check_unit_twist(unit_twist, tolerance=1e-6, strict_check=True):
-    """Input validation for unit twist.
+def check_screw_matrix(screw_matrix, tolerance=1e-6, strict_check=True):
+    """Input validation for screw matrix.
 
-    A unit twist matrix consists of the cross-product matrix of a rotation
+    A screw matrix consists of the cross-product matrix of a rotation
     axis and a translation.
 
     .. math::
@@ -680,8 +680,8 @@ def check_unit_twist(unit_twist, tolerance=1e-6, strict_check=True):
 
     Parameters
     ----------
-    unit_twist : array-like, shape (4, 4)
-        A unit twist consists of a cross-product matrix that represents an
+    screw_matrix : array-like, shape (4, 4)
+        A screw matrix consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
 
     tolerance : float, optional (default: 1e-6)
@@ -693,22 +693,22 @@ def check_unit_twist(unit_twist, tolerance=1e-6, strict_check=True):
 
     Returns
     -------
-    unit_twist : array, shape (4, 4)
-        A unit twist consists of a cross-product matrix that represents an
+    screw_matrix : array, shape (4, 4)
+        A screw matrix consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
     """
-    unit_twist = np.asarray(unit_twist, dtype=np.float)
-    if (unit_twist.ndim != 2 or unit_twist.shape[0] != 4
-            or unit_twist.shape[1] != 4):
+    screw_matrix = np.asarray(screw_matrix, dtype=np.float)
+    if (screw_matrix.ndim != 2 or screw_matrix.shape[0] != 4
+            or screw_matrix.shape[1] != 4):
         raise ValueError("Expected array-like with shape (4, 4), got array-like "
-                         "object with shape %s" % (unit_twist.shape,))
-    if any(unit_twist[3] != 0.0):
-        raise ValueError("Last row of unit twist must only contains zeros.")
+                         "object with shape %s" % (screw_matrix.shape,))
+    if any(screw_matrix[3] != 0.0):
+        raise ValueError("Last row of screw matrix must only contains zeros.")
 
-    check_skew_symmetric_matrix(unit_twist[:3, :3], tolerance, strict_check)
+    check_skew_symmetric_matrix(screw_matrix[:3, :3], tolerance, strict_check)
 
     omega_norm = np.linalg.norm(
-        [unit_twist[2, 1], unit_twist[0, 2], unit_twist[1, 0]])
+        [screw_matrix[2, 1], screw_matrix[0, 2], screw_matrix[1, 0]])
 
     if (abs(omega_norm - 1.0) > np.finfo(float).eps
             and abs(omega_norm) > np.finfo(float).eps):
@@ -716,21 +716,21 @@ def check_unit_twist(unit_twist, tolerance=1e-6, strict_check=True):
             "Norm of rotation axis must either be 0 or 1, but it is %g."
             % omega_norm)
     if abs(omega_norm) < np.finfo(float).eps:
-        v_norm = np.linalg.norm(unit_twist[:3, 3])
+        v_norm = np.linalg.norm(screw_matrix[:3, 3])
         if (abs(v_norm - 1.0) > np.finfo(float).eps
                 and abs(v_norm) > np.finfo(float).eps):
             raise ValueError(
                 "If the norm of the rotation axis is 0, then the direction "
                 "vector must have norm 1 or 0, but it is %g." % v_norm)
 
-    return unit_twist
+    return screw_matrix
 
 
 def check_transform_log(transform_log, tolerance=1e-6, strict_check=True):
     """Input validation for logarithm of transformation.
 
     The logarithm of a transformation :math:`\\left[\\mathcal{S}\\right]\\theta
-    \\in \\mathbb{R}^{4 \\times 4}` are the product of a unit twist and a
+    \\in \\mathbb{R}^{4 \\times 4}` are the product of a screw matrix and a
     scalar :math:`\\theta`.
 
     Parameters
@@ -902,13 +902,13 @@ def screw_axis_from_exponential_coordinates(Stheta):
     return Stheta / theta, theta
 
 
-def screw_axis_from_unit_twist(unit_twist):
-    """Compute screw axis from unit twist.
+def screw_axis_from_screw_matrix(screw_matrix):
+    """Compute screw axis from screw matrix.
 
     Parameters
     ----------
-    unit_twist : array-like, shape (4, 4)
-        A unit twist consists of a cross-product matrix that represents an
+    screw_matrix : array-like, shape (4, 4)
+        A screw matrix consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
 
     Returns
@@ -919,13 +919,13 @@ def screw_axis_from_unit_twist(unit_twist):
         where the first 3 components are related to rotation and the last 3
         components are related to translation.
     """
-    unit_twist = check_unit_twist(unit_twist)
+    screw_matrix = check_screw_matrix(screw_matrix)
 
     screw_axis = np.empty(6)
-    screw_axis[0] = unit_twist[2, 1]
-    screw_axis[1] = unit_twist[0, 2]
-    screw_axis[2] = unit_twist[1, 0]
-    screw_axis[3:] = unit_twist[:3, 3]
+    screw_axis[0] = screw_matrix[2, 1]
+    screw_axis[1] = screw_matrix[0, 2]
+    screw_axis[2] = screw_matrix[1, 0]
+    screw_axis[3:] = screw_matrix[:3, 3]
     return screw_axis
 
 
@@ -1031,8 +1031,8 @@ def exponential_coordinates_from_transform(A2B, strict_check=True):
     return np.hstack((omega_unit, v)) * theta
 
 
-def unit_twist_from_screw_axis(screw_axis):
-    """Compute unit twist from screw axis.
+def screw_matrix_from_screw_axis(screw_axis):
+    """Compute screw matrix from screw axis.
 
     Parameters
     ----------
@@ -1044,22 +1044,22 @@ def unit_twist_from_screw_axis(screw_axis):
 
     Returns
     -------
-    unit_twist : array, shape (4, 4)
-        A unit twist consists of a cross-product matrix that represents an
+    screw_matrix : array, shape (4, 4)
+        A screw matrix consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
     """
     screw_axis = check_screw_axis(screw_axis)
 
     omega = screw_axis[:3]
     v = screw_axis[3:]
-    unit_twist = np.zeros((4, 4))
-    unit_twist[:3, :3] = cross_product_matrix(omega)
-    unit_twist[:3, 3] = v
-    return unit_twist
+    screw_matrix = np.zeros((4, 4))
+    screw_matrix[:3, :3] = cross_product_matrix(omega)
+    screw_matrix[:3, 3] = v
+    return screw_matrix
 
 
-def unit_twist_from_transform_log(transform_log):
-    """Compute unit twist from logarithm of transformation.
+def screw_matrix_from_transform_log(transform_log):
+    """Compute screw matrix from logarithm of transformation.
 
     Parameters
     ----------
@@ -1068,8 +1068,8 @@ def unit_twist_from_transform_log(transform_log):
 
     Returns
     -------
-    unit_twist : array, shape (4, 4)
-        A unit twist consists of a cross-product matrix that represents an
+    screw_matrix : array, shape (4, 4)
+        A screw matrix consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
     """
     transform_log = check_transform_log(transform_log)
@@ -1111,13 +1111,13 @@ def transform_log_from_exponential_coordinates(Stheta):
     return transform_log
 
 
-def transform_log_from_unit_twist(unit_twist, theta):
-    """Compute matrix logarithm of transformation from unit twist and theta.
+def transform_log_from_screw_matrix(screw_matrix, theta):
+    """Compute matrix logarithm of transformation from screw matrix and theta.
 
     Parameters
     ----------
-    unit_twist : array-like, shape (4, 4)
-        A unit twist consists of a cross-product matrix that represents an
+    screw_matrix : array-like, shape (4, 4)
+        A screw matrix consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
 
     theta : float
@@ -1129,8 +1129,8 @@ def transform_log_from_unit_twist(unit_twist, theta):
     transform_log : array, shape (4, 4)
         Matrix logarithm of transformation matrix: [S] * theta.
     """
-    unit_twist = check_unit_twist(unit_twist)
-    return unit_twist * theta
+    screw_matrix = check_screw_matrix(screw_matrix)
+    return screw_matrix * theta
 
 
 def transform_log_from_transform(A2B, strict_check=True):

--- a/pytransform3d/urdf.py
+++ b/pytransform3d/urdf.py
@@ -1,4 +1,7 @@
-"""Load transformations from URDF files."""
+"""Load transformations from URDF files.
+
+See :doc:`transform_manager` for more information.
+"""
 import os
 import numpy as np
 from bs4 import BeautifulSoup

--- a/pytransform3d/visualizer.py
+++ b/pytransform3d/visualizer.py
@@ -313,7 +313,7 @@ try:
                 The resolution of the sphere. The longitues will be split into
                 resolution segments (i.e. there are resolution + 1 latitude lines
                 including the north and south pole). The latitudes will be split
-                into `2 * resolution segments (i.e. there are 2 * resolution
+                into 2 * resolution segments (i.e. there are 2 * resolution
                 longitude lines.)
 
             c : array-like, shape (3,), optional (default: None)
@@ -672,7 +672,7 @@ try:
             The resolution of the sphere. The longitues will be split into
             resolution segments (i.e. there are resolution + 1 latitude lines
             including the north and south pole). The latitudes will be split
-            into `2 * resolution segments (i.e. there are 2 * resolution
+            into 2 * resolution segments (i.e. there are 2 * resolution
             longitude lines.)
 
         c : array-like, shape (3,), optional (default: None)


### PR DESCRIPTION
* Adds functions `vector_projection` and `check_skew_symmetric_matrix`
* Adds screw parameters, screw axis, exponential coordinates of transformations, unit twist, and matrix logarithm as new representations for transformations
* Improves documentation of SE(3)

TODO

- [x] plot pure translation screw
- [x] logarithmic map
- [x] twists from screw axis / screw axis from twist
- [x] S * theta to S and theta
- [x] unit tests
- [x] check skew-symmetric matrices
- [x] Clean up documentation of SO(3) / SE(3)
- [x] Check docstrings

![Figure_1](https://user-images.githubusercontent.com/869592/102022263-f5e06280-3d85-11eb-92a8-a2f047fcee42.png)
