### PR TITLE
[MRG] Normalization of rotation matrices

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -240,8 +240,8 @@ Conversions to Exponential Coordinates
    ~pytransform3d.transformations.exponential_coordinates_from_screw_axis
    ~pytransform3d.transformations.exponential_coordinates_from_transform_log
 
-Conversions to Unit Twist Matrix
---------------------------------
+Conversions to Screw Matrix
+---------------------------
 
 .. autosummary::
    :toctree: _apidoc/

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -23,7 +23,7 @@ Utility Functions
    :template: function.rst
 
    ~pytransform3d.rotations.norm_vector
-   ~pytransform3d.rotations.norm_rotation_matrix
+   ~pytransform3d.rotations.norm_matrix
    ~pytransform3d.rotations.norm_angle
    ~pytransform3d.rotations.norm_axis_angle
    ~pytransform3d.rotations.norm_compact_axis_angle
@@ -60,6 +60,7 @@ Conversions to Rotation Matrix
    ~pytransform3d.rotations.matrix_from_angle
    ~pytransform3d.rotations.passive_matrix_from_angle
    ~pytransform3d.rotations.active_matrix_from_angle
+   ~pytransform3d.rotations.matrix_from_two_vectors
    ~pytransform3d.rotations.matrix_from_axis_angle
    ~pytransform3d.rotations.matrix_from_compact_axis_angle
    ~pytransform3d.rotations.matrix_from_quaternion

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -23,6 +23,7 @@ Utility Functions
    :template: function.rst
 
    ~pytransform3d.rotations.norm_vector
+   ~pytransform3d.rotations.norm_rotation_matrix
    ~pytransform3d.rotations.norm_angle
    ~pytransform3d.rotations.norm_axis_angle
    ~pytransform3d.rotations.norm_compact_axis_angle

--- a/examples/plot_matrix_from_two_vectors.py
+++ b/examples/plot_matrix_from_two_vectors.py
@@ -1,0 +1,28 @@
+"""
+==========================================
+Construct Rotation Matrix from Two Vectors
+==========================================
+
+We compute rotation matrix from two vectors that form a plane. The x-axis will
+point in the same direction as the first vector, the y-axis corresponds to the
+normalized vector rejection of b on a, and the z-axis is the cross product of
+the other basis vectors.
+"""
+print(__doc__)
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+from pytransform3d.rotations import matrix_from_two_vectors, plot_basis, random_vector
+from pytransform3d.plot_utils import plot_vector
+
+
+random_state = np.random.RandomState(1)
+a = random_vector(random_state, 3) * 0.3
+b = random_vector(random_state, 3) * 0.3
+R = matrix_from_two_vectors(a, b)
+
+ax = plot_vector(direction=a, color="r")
+plot_vector(ax=ax, direction=b, color="g")
+plot_basis(ax=ax, R=R)
+plt.show()

--- a/pytransform3d/rotations.py
+++ b/pytransform3d/rotations.py
@@ -45,7 +45,7 @@ def norm_vector(v):
         return np.asarray(v) / norm
 
 
-def norm_rotation_matrix(R):
+def norm_matrix(R):
     """Normalize rotation matrix.
 
     Parameters
@@ -523,6 +523,49 @@ def check_quaternions(Q, unit=True):
         for i in range(len(Q)):
             Q_checked[i] = norm_vector(Q_checked[i])
     return Q_checked
+
+
+def matrix_from_two_vectors(a, b):
+    """Compute rotation matrix from two vectors.
+
+    We assume that the two given vectors form a plane so that we can compute
+    a third, orthogonal vector with the cross product.
+
+    The x-axis will point in the same direction as a, the y-axis corresponds
+    to the normalized vector rejection of b on a, and the z-axis is the
+    cross product of the other basis vectors.
+
+    Parameters
+    ----------
+    a : array-like, shape (3,)
+        First vector, must not be 0
+
+    b : array-like, shape (3,)
+        Second vector, must not be 0 or parallel to v1
+
+    Returns
+    -------
+    R : array, shape (3, 3)
+        Rotation matrix
+    """
+    if np.linalg.norm(a) == 0:
+        raise ValueError("a must not be the zero vector.")
+    if np.linalg.norm(b) == 0:
+        raise ValueError("b must not be the zero vector.")
+
+    c = perpendicular_to_vectors(a, b)
+    if np.linalg.norm(c) == 0:
+        raise ValueError("a and b must not be parallel.")
+
+    a = norm_vector(a)
+
+    b_on_a_projection = vector_projection(b, a)
+    b_on_a_rejection = b - b_on_a_projection
+    b = norm_vector(b_on_a_rejection)
+
+    c = norm_vector(c)
+
+    return np.column_stack((a, b, c))
 
 
 def matrix_from_axis_angle(a):

--- a/pytransform3d/rotations.py
+++ b/pytransform3d/rotations.py
@@ -35,7 +35,7 @@ def norm_vector(v):
 
     Returns
     -------
-    u : array-like, shape (n,)
+    u : array, shape (n,)
         nd unit vector with norm 1 or the zero vector
     """
     norm = np.linalg.norm(v)
@@ -43,6 +43,27 @@ def norm_vector(v):
         return v
     else:
         return np.asarray(v) / norm
+
+
+def norm_rotation_matrix(R):
+    """Normalize rotation matrix.
+
+    Parameters
+    ----------
+    R : array-like, shape (3, 3)
+        Rotation matrix with small numerical errors
+
+    Returns
+    -------
+    R : array, shape (3, 3)
+        Normalized rotation matrix
+    """
+    R = np.asarray(R)
+    c2 = R[:, 1]
+    c3 = norm_vector(R[:, 2])
+    c1 = norm_vector(np.cross(c2, c3))
+    c2 = norm_vector(np.cross(c3, c1))
+    return np.column_stack((c1, c2, c3))
 
 
 def norm_angle(a):

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -1313,12 +1313,10 @@ def test_norm_rotation_matrix():
     assert_equal(np.linalg.det(R), 1.0)
 
     R = np.eye(3)
-    for _ in range(100):
-        R = R.dot(active_matrix_from_extrinsic_roll_pitch_yaw([0.2, 0.3, 0.4]))
-    assert_true(np.linalg.det(R) != 0.0)
+    R[1, 1] += 0.3
     R_norm = norm_matrix(R)
-    assert_equal(np.linalg.det(R_norm), 1.0)
-    assert_array_almost_equal(R, R_norm)
+    assert_almost_equal(np.linalg.det(R_norm), 1.0)
+    assert_array_almost_equal(np.eye(3), R_norm)
 
 
 def test_matrix_from_two_vectors():

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -1301,3 +1301,21 @@ def test_deactivate_rotation_matrix_precision_error():
     with warnings.catch_warnings(record=True) as w:
         check_matrix(R, strict_check=False)
         assert_equal(len(w), 2)
+
+
+def test_norm_rotation_matrix():
+    R = norm_rotation_matrix(np.eye(3))
+    assert_array_equal(R, np.eye(3))
+
+    R[1, 0] += np.finfo(float).eps
+    R = norm_rotation_matrix(R)
+    assert_array_equal(R, np.eye(3))
+    assert_equal(np.linalg.det(R), 1.0)
+
+    R = np.eye(3)
+    for _ in range(100):
+        R = R.dot(active_matrix_from_extrinsic_roll_pitch_yaw([0.2, 0.3, 0.4]))
+    assert_true(np.linalg.det(R) != 0.0)
+    R_norm = norm_rotation_matrix(R)
+    assert_equal(np.linalg.det(R_norm), 1.0)
+    assert_array_almost_equal(R, R_norm)


### PR DESCRIPTION
Fixes #78 

* Adds functions `norm_matrix` and `matrix_from_two_vectors`