### PR TITLE
Fix DeprecationWarning for `numpy>=1.20`

### DIFF
--- a/pytransform3d/rotations.py
+++ b/pytransform3d/rotations.py
@@ -368,7 +368,7 @@ def check_skew_symmetric_matrix(V, tolerance=1e-6, strict_check=True):
     V : array-like, shape (3, 3)
         Validated cross-product matrix
     """
-    V = np.asarray(V, dtype=np.float)
+    V = np.asarray(V, dtype=np.float64)
     if V.ndim != 2 or V.shape[0] != 3 or V.shape[1] != 3:
         raise ValueError("Expected skew-symmetric matrix with shape (3, 3), "
                          "got array-like object with shape %s" % (V.shape,))
@@ -406,7 +406,7 @@ def check_matrix(R, tolerance=1e-6, strict_check=True):
     R : array, shape (3, 3)
         Validated rotation matrix
     """
-    R = np.asarray(R, dtype=np.float)
+    R = np.asarray(R, dtype=np.float64)
     if R.ndim != 2 or R.shape[0] != 3 or R.shape[1] != 3:
         raise ValueError("Expected rotation matrix with shape (3, 3), got "
                          "array-like object with shape %s" % (R.shape,))
@@ -445,7 +445,7 @@ def check_axis_angle(a):
     a : array, shape (4,)
         Validated axis of rotation and rotation angle: (x, y, z, angle)
     """
-    a = np.asarray(a, dtype=np.float)
+    a = np.asarray(a, dtype=np.float64)
     if a.ndim != 1 or a.shape[0] != 4:
         raise ValueError("Expected axis and angle in array with shape (4,), "
                          "got array-like object with shape %s" % (a.shape,))
@@ -465,7 +465,7 @@ def check_compact_axis_angle(a):
     a : array, shape (3,)
         Validated axis of rotation and rotation angle: angle * (x, y, z)
     """
-    a = np.asarray(a, dtype=np.float)
+    a = np.asarray(a, dtype=np.float64)
     if a.ndim != 1 or a.shape[0] != 3:
         raise ValueError("Expected axis and angle in array with shape (3,), "
                          "got array-like object with shape %s" % (a.shape,))
@@ -488,7 +488,7 @@ def check_quaternion(q, unit=True):
     q : array-like, shape (4,)
         Validated quaternion to represent rotation: (w, x, y, z)
     """
-    q = np.asarray(q, dtype=np.float)
+    q = np.asarray(q, dtype=np.float64)
     if q.ndim != 1 or q.shape[0] != 4:
         raise ValueError("Expected quaternion with shape (4,), got "
                          "array-like object with shape %s" % (q.shape,))
@@ -514,7 +514,7 @@ def check_quaternions(Q, unit=True):
     Q : array-like, shape (n_steps, 4)
         Validated quaternions to represent rotations: (w, x, y, z)
     """
-    Q_checked = np.asarray(Q, dtype=np.float)
+    Q_checked = np.asarray(Q, dtype=np.float64)
     if Q_checked.ndim != 2 or Q_checked.shape[1] != 4:
         raise ValueError(
             "Expected quaternion array with shape (n_steps, 4), got "

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -248,12 +248,12 @@ def test_check_matrix():
     R_list = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
     R = pr.check_matrix(R_list)
     assert_equal(type(R), np.ndarray)
-    assert_equal(R.dtype, np.float)
+    assert_equal(R.dtype, np.float64)
 
     R_int_array = np.eye(3, dtype=np.int)
     R = pr.check_matrix(R_int_array)
     assert_equal(type(R), np.ndarray)
-    assert_equal(R.dtype, np.float)
+    assert_equal(R.dtype, np.float64)
 
     R_array = np.eye(3)
     R = pr.check_matrix(R_array)
@@ -282,7 +282,7 @@ def test_check_axis_angle():
     a = pr.check_axis_angle(a_list)
     assert_array_almost_equal(a_list, a)
     assert_equal(type(a), np.ndarray)
-    assert_equal(a.dtype, np.float)
+    assert_equal(a.dtype, np.float64)
 
     random_state = np.random.RandomState(0)
     a = np.empty(4)
@@ -308,7 +308,7 @@ def test_check_compact_axis_angle():
     a = pr.check_compact_axis_angle(a_list)
     assert_array_almost_equal(a_list, a)
     assert_equal(type(a), np.ndarray)
-    assert_equal(a.dtype, np.float)
+    assert_equal(a.dtype, np.float64)
 
     random_state = np.random.RandomState(0)
     a = pr.norm_vector(pr.random_vector(random_state, 3))
@@ -332,7 +332,7 @@ def test_check_quaternion():
     q = pr.check_quaternion(q_list)
     assert_array_almost_equal(q_list, q)
     assert_equal(type(q), np.ndarray)
-    assert_equal(q.dtype, np.float)
+    assert_equal(q.dtype, np.float64)
 
     random_state = np.random.RandomState(0)
     q = random_state.randn(4)
@@ -355,7 +355,7 @@ def test_check_quaternions():
     Q = pr.check_quaternions(Q_list)
     assert_array_almost_equal(Q_list, Q)
     assert_equal(type(Q), np.ndarray)
-    assert_equal(Q.dtype, np.float)
+    assert_equal(Q.dtype, np.float64)
     assert_equal(Q.ndim, 2)
     assert_array_equal(Q.shape, (1, 4))
 

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -42,7 +42,7 @@ def test_check_transform():
     A2B = np.eye(4, dtype=int)
     A2B = check_transform(A2B)
     assert_equal(type(A2B), np.ndarray)
-    assert_equal(A2B.dtype, np.float)
+    assert_equal(A2B.dtype, np.float64)
 
     A2B[:3, :3] = np.array([[1, 1, 1], [0, 0, 0], [2, 2, 2]])
     assert_raises_regexp(ValueError, "rotation matrix", check_transform, A2B)

--- a/pytransform3d/transformations.py
+++ b/pytransform3d/transformations.py
@@ -36,7 +36,7 @@ def check_transform(A2B, strict_check=True):
     A2B : array, shape (4, 4)
         Validated transform from frame A to frame B
     """
-    A2B = np.asarray(A2B, dtype=np.float)
+    A2B = np.asarray(A2B, dtype=np.float64)
     if A2B.ndim != 2 or A2B.shape[0] != 4 or A2B.shape[1] != 4:
         raise ValueError("Expected homogeneous transformation matrix with "
                          "shape (4, 4), got array-like object with shape %s"
@@ -66,7 +66,7 @@ def check_pq(pq):
         Validated position and orientation quaternion:
          (x, y, z, qw, qx, qy, qz)
     """
-    pq = np.asarray(pq, dtype=np.float)
+    pq = np.asarray(pq, dtype=np.float64)
     if pq.ndim != 1 or pq.shape[0] != 7:
         raise ValueError("Expected position and orientation quaternion in a "
                          "1D array, got array-like object with shape %s"
@@ -598,14 +598,14 @@ def check_screw_parameters(q, s_axis, h):
         Pitch of the screw. The pitch is the ratio of translation and rotation
         of the screw axis. Infinite pitch indicates pure translation.
     """
-    s_axis = np.asarray(s_axis, dtype=np.float)
+    s_axis = np.asarray(s_axis, dtype=np.float64)
     if s_axis.ndim != 1 or s_axis.shape[0] != 3:
         raise ValueError("Expected 3D vector with shape (3,), got array-like "
                          "object with shape %s" % (s_axis.shape,))
     if np.linalg.norm(s_axis) == 0.0:
         raise ValueError("s_axis must not have norm 0")
 
-    q = np.asarray(q, dtype=np.float)
+    q = np.asarray(q, dtype=np.float64)
     if q.ndim != 1 or q.shape[0] != 3:
         raise ValueError("Expected 3D vector with shape (3,), got array-like "
                          "object with shape %s" % (q.shape,))
@@ -645,7 +645,7 @@ def check_screw_axis(screw_axis):
         where the first 3 components are related to rotation and the last 3
         components are related to translation.
     """
-    screw_axis = np.asarray(screw_axis, dtype=np.float)
+    screw_axis = np.asarray(screw_axis, dtype=np.float64)
     if screw_axis.ndim != 1 or screw_axis.shape[0] != 6:
         raise ValueError("Expected 3D vector with shape (6,), got array-like "
                          "object with shape %s" % (screw_axis.shape,))
@@ -695,7 +695,7 @@ def check_exponential_coordinates(Stheta):
         will be represented by a negative screw axis instead. This is relevant
         if you want to recover theta from exponential coordinates.
     """
-    Stheta = np.asarray(Stheta, dtype=np.float)
+    Stheta = np.asarray(Stheta, dtype=np.float64)
     if Stheta.ndim != 1 or Stheta.shape[0] != 6:
         raise ValueError("Expected array-like with shape (6,), got array-like "
                          "object with shape %s" % (Stheta.shape,))
@@ -746,7 +746,7 @@ def check_screw_matrix(screw_matrix, tolerance=1e-6, strict_check=True):
         A screw matrix consists of a cross-product matrix that represents an
         axis of rotation, a translation, and a row of zeros.
     """
-    screw_matrix = np.asarray(screw_matrix, dtype=np.float)
+    screw_matrix = np.asarray(screw_matrix, dtype=np.float64)
     if (screw_matrix.ndim != 2 or screw_matrix.shape[0] != 4
             or screw_matrix.shape[1] != 4):
         raise ValueError(
@@ -800,7 +800,7 @@ def check_transform_log(transform_log, tolerance=1e-6, strict_check=True):
     transform_log : array, shape (4, 4)
         Matrix logarithm of transformation matrix: [S] * theta.
     """
-    transform_log = np.asarray(transform_log, dtype=np.float)
+    transform_log = np.asarray(transform_log, dtype=np.float64)
     if (transform_log.ndim != 2 or transform_log.shape[0] != 4
             or transform_log.shape[1] != 4):
         raise ValueError(
@@ -1337,7 +1337,7 @@ def check_dual_quaternion(dq, unit=True):
         :math:`p_w^2 + p_x^2 + p_y^2 + p_z^2 = 1` and
         :math:`p_w q_w + p_x q_x + p_y q_y + p_z q_z = 0`.
     """
-    dq = np.asarray(dq, dtype=np.float)
+    dq = np.asarray(dq, dtype=np.float64)
     if dq.ndim != 1 or dq.shape[0] != 8:
         raise ValueError("Expected dual quaternion with shape (8,), got "
                          "array-like object with shape %s" % (dq.shape,))


### PR DESCRIPTION
See #114 for a further description.

All instances of `np.float` are replaced with `np.float64`.