### PR TITLE
[MRG] Capsule pose defines center of line segment

### DIFF
--- a/pytransform3d/plot_utils/_plot_functions.py
+++ b/pytransform3d/plot_utils/_plot_functions.py
@@ -149,6 +149,8 @@ def plot_cylinder(ax=None, length=1.0, radius=1.0, thickness=0.0,
                   alpha=1.0, color="k"):
     """Plot cylinder.
 
+    A cylinder is the volume covered by a disk moving along a line segment.
+
     Parameters
     ----------
     ax : Matplotlib 3d axis, optional (default: None)
@@ -402,13 +404,13 @@ def plot_capsule(ax=None, A2B=np.eye(4), height=1.0, radius=1.0,
         If the axis is None, a new 3d axis will be created
 
     A2B : array-like, shape (4, 4)
-        Frame of the capsule, located at the start of the line segment.
+        Frame of the capsule, located at the center of the line segment.
 
     height : float, optional (default: 1)
-        Height of the capsule along its z-axis
+        Height of the capsule along its z-axis.
 
     radius : float, optional (default: 1)
-        Radius of the capsule
+        Radius of the capsule.
 
     ax_s : float, optional (default: 1)
         Scaling of the new matplotlib 3d axis
@@ -439,7 +441,8 @@ def plot_capsule(ax=None, A2B=np.eye(4), height=1.0, radius=1.0,
     x = radius * np.sin(phi) * np.cos(theta)
     y = radius * np.sin(phi) * np.sin(theta)
     z = radius * np.cos(phi)
-    z[:len(z) // 2] += height
+    z[len(z) // 2:] -= 0.5 * height
+    z[:len(z) // 2] += 0.5 * height
 
     shape = x.shape
 

--- a/pytransform3d/visualizer/_artists.py
+++ b/pytransform3d/visualizer/_artists.py
@@ -332,16 +332,19 @@ class Box(Artist):
 class Cylinder(Artist):
     """Cylinder.
 
+    A cylinder is the volume covered by a disk moving along a line segment.
+
     Parameters
     ----------
     length : float, optional (default: 1)
-        Length of the cylinder
+        Length of the cylinder.
 
     radius : float, optional (default: 1)
-        Radius of the cylinder
+        Radius of the cylinder.
 
     A2B : array-like, shape (4, 4)
-        Center of the cylinder
+        Pose of the cylinder. The position corresponds to the center of the
+        line segment and the z-axis to the direction of the line segment.
 
     resolution : int, optional (default: 20)
         The circles will be split into resolution segments.
@@ -527,13 +530,14 @@ class Capsule(Artist):
     Parameters
     ----------
     height : float, optional (default: 1)
-        Height of the capsule along its z-axis
+        Height of the capsule along its z-axis.
 
     radius : float, optional (default: 1)
-        Radius of the capsule
+        Radius of the capsule.
 
     A2B : array-like, shape (4, 4)
-        Pose of the capsule.
+        Pose of the capsule. The position corresponds to the center of the line
+        segment and the z-axis to the direction of the line segment.
 
     resolution : int, optional (default: 20)
         The resolution of the half spheres. The longitudes will be split into
@@ -550,7 +554,8 @@ class Capsule(Artist):
         self.capsule = o3d.geometry.TriangleMesh.create_sphere(
             radius, resolution)
         vertices = np.asarray(self.capsule.vertices)
-        vertices[vertices[:, 2] > 0, 2] += height
+        vertices[vertices[:, 2] < 0, 2] -= 0.5 * height
+        vertices[vertices[:, 2] > 0, 2] += 0.5 * height
         self.capsule.vertices = o3d.utility.Vector3dVector(vertices)
         self.capsule.compute_vertex_normals()
         if c is not None:

--- a/pytransform3d/visualizer/_figure.py
+++ b/pytransform3d/visualizer/_figure.py
@@ -367,13 +367,14 @@ class Figure:
         Parameters
         ----------
         length : float, optional (default: 1)
-            Length of the cylinder
+            Length of the cylinder.
 
         radius : float, optional (default: 1)
-            Radius of the cylinder
+            Radius of the cylinder.
 
         A2B : array-like, shape (4, 4)
-            Center of the cylinder
+            Pose of the cylinder. The position corresponds to the center of the
+            line segment and the z-axis to the direction of the line segment.
 
         resolution : int, optional (default: 20)
             The circle will be split into resolution segments
@@ -459,13 +460,14 @@ class Figure:
         Parameters
         ----------
         height : float, optional (default: 1)
-            Height of the capsule along its z-axis
+            Height of the capsule along its z-axis.
 
         radius : float, optional (default: 1)
-            Radius of the capsule
+            Radius of the capsule.
 
         A2B : array-like, shape (4, 4)
-            Pose of the capsule.
+            Pose of the capsule. The position corresponds to the center of the
+            line segment and the z-axis to the direction of the line segment.
 
         resolution : int, optional (default: 20)
             The resolution of the capsule. The longitudes will be split into


### PR DESCRIPTION
This is a breaking change for the current development version. It is not a breaking change for 1.9.1 and previous releases because capsule visualizations were not included previously.