### PR TITLE
add ability to hide label indicator

### DIFF
--- a/pytransform3d/plot_utils/_artists.py
+++ b/pytransform3d/plot_utils/_artists.py
@@ -20,7 +20,12 @@ class Frame(artist.Artist):
     s : float, optional (default: 1)
         Length of basis vectors
 
-    Other arguments except 'c' and 'color' are passed on to Line3D.
+    kwargs : 
+        'draw_label_indicator' (default: True) controls whether the line from the frame origin to frame label is drawn. 
+
+    Other arguments except 'c', 'color' and 'draw_label_indicator' are passed on to Line3D. 
+    
+
     """
     def __init__(self, A2B, label=None, s=1.0, **kwargs):
         super(Frame, self).__init__()
@@ -30,7 +35,7 @@ class Frame(artist.Artist):
         if "color" in kwargs:
             kwargs.pop("color")
 
-        self.hide_label_indicator = kwargs.pop("hide_label_indicator", False)
+        self.draw_label_indicator = kwargs.pop("draw_label_indicator", True)
 
         self.s = s
 
@@ -42,7 +47,7 @@ class Frame(artist.Artist):
         self.label = label
 
         if self.draw_label:
-            if not self.hide_label_indicator:
+            if self.draw_label_indicator:
                 self.label_indicator = Line3D([], [], [], color="k", **kwargs)
             self.label_text = Text3D(0, 0, 0, text="", zdir="x")
 
@@ -72,7 +77,7 @@ class Frame(artist.Artist):
                 label = self.label
             label_pos = p + 0.5 * self.s * (R[:, 0] + R[:, 1] + R[:, 2])
 
-            if not self.hide_label_indicator:
+            if self.draw_label_indicator:
                 self.label_indicator.set_data(
                     np.array([p[0], label_pos[0]]),
                     np.array([p[1], label_pos[1]]))
@@ -89,7 +94,7 @@ class Frame(artist.Artist):
         for b in [self.x_axis, self.y_axis, self.z_axis]:
             b.draw(renderer, *args, **kwargs)
         if self.draw_label:
-            if not self.hide_label_indicator:
+            if self.draw_label_indicator:
                 self.label_indicator.draw(renderer, *args, **kwargs)
             self.label_text.draw(renderer, *args, **kwargs)
         super(Frame, self).draw(renderer, *args, **kwargs)
@@ -99,7 +104,7 @@ class Frame(artist.Artist):
         for b in [self.x_axis, self.y_axis, self.z_axis]:
             axis.add_line(b)
         if self.draw_label:
-            if not self.hide_label_indicator:
+            if self.draw_label_indicator:
                 axis.add_line(self.label_indicator)
             axis._add_text(self.label_text)
 

--- a/pytransform3d/plot_utils/_artists.py
+++ b/pytransform3d/plot_utils/_artists.py
@@ -30,6 +30,8 @@ class Frame(artist.Artist):
         if "color" in kwargs:
             kwargs.pop("color")
 
+        self.hide_label_indicator = kwargs.pop("hide_label_indicator", False)
+
         self.s = s
 
         self.x_axis = Line3D([], [], [], color="r", **kwargs)
@@ -40,7 +42,8 @@ class Frame(artist.Artist):
         self.label = label
 
         if self.draw_label:
-            self.label_indicator = Line3D([], [], [], color="k", **kwargs)
+            if not self.hide_label_indicator:
+                self.label_indicator = Line3D([], [], [], color="k", **kwargs)
             self.label_text = Text3D(0, 0, 0, text="", zdir="x")
 
         self.set_data(A2B, label)
@@ -69,11 +72,12 @@ class Frame(artist.Artist):
                 label = self.label
             label_pos = p + 0.5 * self.s * (R[:, 0] + R[:, 1] + R[:, 2])
 
-            self.label_indicator.set_data(
-                np.array([p[0], label_pos[0]]),
-                np.array([p[1], label_pos[1]]))
-            self.label_indicator.set_3d_properties(
-                np.array([p[2], label_pos[2]]))
+            if not self.hide_label_indicator:
+                self.label_indicator.set_data(
+                    np.array([p[0], label_pos[0]]),
+                    np.array([p[1], label_pos[1]]))
+                self.label_indicator.set_3d_properties(
+                    np.array([p[2], label_pos[2]]))
 
             self.label_text.set_text(label)
             self.label_text.set_position([label_pos[0], label_pos[1]])
@@ -85,7 +89,8 @@ class Frame(artist.Artist):
         for b in [self.x_axis, self.y_axis, self.z_axis]:
             b.draw(renderer, *args, **kwargs)
         if self.draw_label:
-            self.label_indicator.draw(renderer, *args, **kwargs)
+            if not self.hide_label_indicator:
+                self.label_indicator.draw(renderer, *args, **kwargs)
             self.label_text.draw(renderer, *args, **kwargs)
         super(Frame, self).draw(renderer, *args, **kwargs)
 
@@ -94,7 +99,8 @@ class Frame(artist.Artist):
         for b in [self.x_axis, self.y_axis, self.z_axis]:
             axis.add_line(b)
         if self.draw_label:
-            axis.add_line(self.label_indicator)
+            if not self.hide_label_indicator:
+                axis.add_line(self.label_indicator)
             axis._add_text(self.label_text)
 
 

--- a/pytransform3d/test/test_plot_utils.py
+++ b/pytransform3d/test/test_plot_utils.py
@@ -67,6 +67,16 @@ def test_frame():
     finally:
         ax.remove()
 
+def test_frame_no_indicator():
+    ax = make_3d_axis(1.0)
+    try:
+        frame = Frame(np.eye(4), label="Frame", s=0.1, draw_label_indicator=False)
+        frame.add_frame(ax)
+        assert_equal(len(ax.lines), 3)  # 3 axes and omit black line to text
+        assert_equal(len(ax.texts), 1)  # label
+    finally:
+        ax.remove()
+
 
 def test_labeled_frame():
     ax = make_3d_axis(1.0)
@@ -242,3 +252,4 @@ def test_plot_length_variable():
         assert_equal(len(ax.texts), 1)
     finally:
         ax.remove()
+        


### PR DESCRIPTION
The label indicator can look cluttered in certain views and for those not familiar with rgb conventions it may be confusing. I prefer the look of the axes without the indicator, so this PR attempts to make it a little cleaner. I did it through kwargs instead of explicit parameter to be minimally invasive.