### PR TITLE
Fix Arrow3D for matplotlib 3.5

### DIFF
--- a/pytransform3d/plot_utils/_artists.py
+++ b/pytransform3d/plot_utils/_artists.py
@@ -295,3 +295,7 @@ class Arrow3D(FancyArrowPatch):
         xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, M)
         self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
         super(Arrow3D, self).draw(renderer)
+
+    def do_3d_projection(self, renderer=None):
+        # This supports both matplotlib 3.4 and 3.5
+        return 0


### PR DESCRIPTION
Fixes #176 