### PR TITLE
[WIP] Solve ambiguities in interpolations

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -390,6 +390,7 @@ Testing
    ~pytransform3d.batch_rotations.batch_concatenate_quaternions
    ~pytransform3d.batch_rotations.batch_quaternion_wxyz_from_xyzw
    ~pytransform3d.batch_rotations.batch_quaternion_xyzw_from_wxyz
+   ~pytransform3d.batch_rotations.smooth_quaternion_trajectory
 
 
 :mod:`pytransform3d.trajectories`

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -102,6 +102,7 @@ Quaternion and Axis-Angle Operations
    ~pytransform3d.rotations.concatenate_quaternions
    ~pytransform3d.rotations.q_prod_vector
    ~pytransform3d.rotations.q_conj
+   ~pytransform3d.rotations.pick_closest_quaternion
    ~pytransform3d.rotations.quaternion_slerp
    ~pytransform3d.rotations.quaternion_dist
    ~pytransform3d.rotations.quaternion_diff

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -417,6 +417,7 @@ Testing
    ~pytransform3d.trajectories.batch_concatenate_dual_quaternions
    ~pytransform3d.trajectories.batch_dq_prod_vector
    ~pytransform3d.trajectories.plot_trajectory
+   ~pytransform3d.trajectories.mirror_screw_axis_direction
 
 
 :mod:`pytransform3d.coordinates`

--- a/pytransform3d/batch_rotations.py
+++ b/pytransform3d/batch_rotations.py
@@ -7,7 +7,8 @@ All functions operate on nd arrays, where the last dimension (vectors) or
 the last two dimensions (matrices) contain individual rotations.
 """
 import numpy as np
-from .rotations import angle_between_vectors, slerp_weights
+from .rotations import (
+    angle_between_vectors, slerp_weights, pick_closest_quaternion)
 
 
 def norm_vectors(V, out=None):
@@ -517,6 +518,7 @@ def quaternion_slerp_batch(start, end, t, shortest_path=False):
 
     shortest_path : bool, optional (default: False)
         Resolve sign ambiguity before interpolation to find the shortest path.
+        The end quaternion will be picked to be close to the start quaternion.
 
     Returns
     -------
@@ -525,7 +527,7 @@ def quaternion_slerp_batch(start, end, t, shortest_path=False):
     """
     t = np.asarray(t)
     if shortest_path:
-        raise NotImplementedError()
+        end = pick_closest_quaternion(end, start)
     angle = angle_between_vectors(start, end)
     w1, w2 = slerp_weights(angle, t)
     return (w1[:, np.newaxis] * start[np.newaxis]

--- a/pytransform3d/batch_rotations.py
+++ b/pytransform3d/batch_rotations.py
@@ -501,7 +501,7 @@ def quaternions_from_matrices(Rs, out=None):
     return out
 
 
-def quaternion_slerp_batch(start, end, t):
+def quaternion_slerp_batch(start, end, t, shortest_path=False):
     """Spherical linear interpolation for a batch of steps.
 
     Parameters
@@ -515,12 +515,17 @@ def quaternion_slerp_batch(start, end, t):
     t : array-like, shape (n_steps,)
         Steps between start and goal, must be in interval [0, 1]
 
+    shortest_path : bool, optional (default: False)
+        Resolve sign ambiguity before interpolation to find the shortest path.
+
     Returns
     -------
     Q : array, shape (n_steps, 4)
         Interpolated unit quaternions
     """
     t = np.asarray(t)
+    if shortest_path:
+        raise NotImplementedError()
     angle = angle_between_vectors(start, end)
     w1, w2 = slerp_weights(angle, t)
     return (w1[:, np.newaxis] * start[np.newaxis]

--- a/pytransform3d/batch_rotations.pyi
+++ b/pytransform3d/batch_rotations.pyi
@@ -53,7 +53,7 @@ def quaternions_from_matrices(
 
 def quaternion_slerp_batch(
         start: npt.ArrayLike, end: npt.ArrayLike,
-        t: npt.ArrayLike) -> np.ndarray: ...
+        t: npt.ArrayLike, shortest_path: bool = ...) -> np.ndarray: ...
 
 
 def batch_concatenate_quaternions(

--- a/pytransform3d/batch_rotations.pyi
+++ b/pytransform3d/batch_rotations.pyi
@@ -1,6 +1,6 @@
 import numpy as np
 import numpy.typing as npt
-from typing import Union
+from typing import Union, AnyStr
 
 
 def norm_vectors(
@@ -63,10 +63,17 @@ def batch_concatenate_quaternions(
 
 def batch_q_conj(Q: npt.ArrayLike) -> np.ndarray: ...
 
+
 def batch_quaternion_wxyz_from_xyzw(
     Q_xyzw: npt.ArrayLike,
     out: Union[np.ndarray, None] = ...) -> np.ndarray: ...
 
+
 def batch_quaternion_xyzw_from_wxyz(
     Q_wxyz: npt.ArrayLike,
     out: Union[np.ndarray, None] = ...) -> np.ndarray: ...
+
+
+def smooth_quaternion_trajectory(
+    Q: npt.ArrayLike,
+    start_component_positive: AnyStr = ...) -> np.ndarray: ...

--- a/pytransform3d/rotations/__init__.py
+++ b/pytransform3d/rotations/__init__.py
@@ -82,8 +82,8 @@ from ._conversions import (
 from ._quaternion_operations import (
     quaternion_integrate, quaternion_gradient, concatenate_quaternions, q_conj,
     q_prod_vector, quaternion_diff, quaternion_dist)
-from ._slerp import (slerp_weights, quaternion_slerp, axis_angle_slerp,
-                     rotor_slerp)
+from ._slerp import (slerp_weights, pick_closest_quaternion, quaternion_slerp,
+                     axis_angle_slerp, rotor_slerp)
 from ._testing import (
     assert_quaternion_equal, assert_axis_angle_equal,
     assert_compact_axis_angle_equal, assert_euler_xyz_equal,
@@ -210,6 +210,7 @@ __all__ = [
     "quaternion_diff",
     "quaternion_dist",
     "slerp_weights",
+    "pick_closest_quaternion",
     "quaternion_slerp",
     "axis_angle_slerp",
     "assert_quaternion_equal",

--- a/pytransform3d/rotations/_slerp.py
+++ b/pytransform3d/rotations/_slerp.py
@@ -2,6 +2,7 @@
 import numpy as np
 from ._utils import (check_axis_angle, check_quaternion, angle_between_vectors,
                      check_rotor)
+from ._constants import eps
 
 
 def axis_angle_slerp(start, end, t):
@@ -57,7 +58,14 @@ def quaternion_slerp(start, end, t, shortest_path=False):
     start = check_quaternion(start)
     end = check_quaternion(end)
     if shortest_path:
-        raise NotImplementedError()
+        if ((abs(start[0]) > eps and np.sign(start[0]) != np.sign(end[0]))
+                or (abs(start[1]) > eps
+                    and np.sign(start[1]) != np.sign(end[1]))
+                or (abs(start[2]) > eps
+                    and np.sign(start[2]) != np.sign(end[2]))
+                or (abs(start[3]) > eps
+                    and np.sign(start[3]) != np.sign(end[3]))):
+            end = -end
     angle = angle_between_vectors(start, end)
     w1, w2 = slerp_weights(angle, t)
     return w1 * start + w2 * end

--- a/pytransform3d/rotations/_slerp.py
+++ b/pytransform3d/rotations/_slerp.py
@@ -47,7 +47,7 @@ def quaternion_slerp(start, end, t, shortest_path=False):
         Position between start and goal
 
     shortest_path : bool, optional (default: False)
-        Resolve sign ambiguity before interpolation to find shortest path.
+        Resolve sign ambiguity before interpolation to find the shortest path.
 
     Returns
     -------

--- a/pytransform3d/rotations/_slerp.py
+++ b/pytransform3d/rotations/_slerp.py
@@ -2,7 +2,6 @@
 import numpy as np
 from ._utils import (check_axis_angle, check_quaternion, angle_between_vectors,
                      check_rotor)
-from ._constants import eps
 
 
 def axis_angle_slerp(start, end, t):
@@ -17,7 +16,7 @@ def axis_angle_slerp(start, end, t):
         Goal axis of rotation and rotation angle: (x, y, z, angle)
 
     t : float in [0, 1]
-        Position between start and goal
+        Position between start and end
 
     Returns
     -------
@@ -45,10 +44,11 @@ def quaternion_slerp(start, end, t, shortest_path=False):
         End unit quaternion to represent rotation: (w, x, y, z)
 
     t : float in [0, 1]
-        Position between start and goal
+        Position between start and end
 
     shortest_path : bool, optional (default: False)
         Resolve sign ambiguity before interpolation to find the shortest path.
+        The end quaternion will be picked to be close to the start quaternion.
 
     Returns
     -------
@@ -58,17 +58,64 @@ def quaternion_slerp(start, end, t, shortest_path=False):
     start = check_quaternion(start)
     end = check_quaternion(end)
     if shortest_path:
-        if ((abs(start[0]) > eps and np.sign(start[0]) != np.sign(end[0]))
-                or (abs(start[1]) > eps
-                    and np.sign(start[1]) != np.sign(end[1]))
-                or (abs(start[2]) > eps
-                    and np.sign(start[2]) != np.sign(end[2]))
-                or (abs(start[3]) > eps
-                    and np.sign(start[3]) != np.sign(end[3]))):
-            end = -end
+        end = _pick_closest_quaternion(end, start)
     angle = angle_between_vectors(start, end)
     w1, w2 = slerp_weights(angle, t)
     return w1 * start + w2 * end
+
+
+def pick_closest_quaternion(quaternion, target_quaternion):
+    """Resolve quaternion ambiguity and pick the closest one to the target.
+
+    .. warning::
+        There are always two quaternions that represent the exact same
+        orientation: q and -q. The problem is that a DMP that moves from q to q
+        does not move at all, while a DMP that moves from q to -q moves a lot.
+        We have to make sure that start_y always contains the quaternion
+        representation that is closest to the previous start_y!
+
+    Parameters
+    ----------
+    quaternion : array-like, shape (4,)
+        Quaternion (w, x, y, z) of which we are unsure whether we want to
+        select quaternion or -quaternion.
+
+    target_quaternion : array-like, shape (4,)
+        Target quaternion (w, x, y, z) to which we want to be close.
+
+    Returns
+    -------
+    closest_quaternion : array, shape (4,)
+        Quaternion that is closest (Euclidean norm) to the target quaternion.
+    """
+    quaternion = check_quaternion(quaternion)
+    target_quaternion = check_quaternion(target_quaternion)
+    return _pick_closest_quaternion(quaternion, target_quaternion)
+
+
+def _pick_closest_quaternion(quaternion, target_quaternion):
+    """Resolve quaternion ambiguity and pick the closest one to the target.
+
+    This is an internal function that does not validate the inputs.
+
+    Parameters
+    ----------
+    quaternion : array, shape (4,)
+        Quaternion (w, x, y, z) of which we are unsure whether we want to
+        select quaternion or -quaternion.
+
+    target_quaternion : array, shape (4,)
+        Target quaternion (w, x, y, z) to which we want to be close.
+
+    Returns
+    -------
+    closest_quaternion : array, shape (4,)
+        Quaternion that is closest (Euclidean norm) to the target quaternion.
+    """
+    if (np.linalg.norm(-quaternion - target_quaternion) <
+            np.linalg.norm(quaternion - target_quaternion)):
+        return -quaternion
+    return quaternion
 
 
 def rotor_slerp(start, end, t):
@@ -83,7 +130,7 @@ def rotor_slerp(start, end, t):
         Rotor: (a, b_yz, b_zx, b_xy)
 
     t : float in [0, 1]
-        Position between start and goal
+        Position between start and end
 
     Returns
     -------
@@ -96,7 +143,24 @@ def rotor_slerp(start, end, t):
 
 
 def slerp_weights(angle, t):
-    """Compute weights of start and end for spherical linear interpolation."""
+    """Compute weights of start and end for spherical linear interpolation.
+
+    Parameters
+    ----------
+    angle : float
+        Rotation angle.
+
+    t : float or array, shape (n_steps,)
+        Position between start and end
+
+    Returns
+    -------
+    w1 : float or array, shape (n_steps,)
+        Weights for quaternion 1
+
+    w2 : float or array, shape (n_steps,)
+        Weights for quaternion 2
+    """
     if angle == 0.0:
         return np.ones_like(t), np.zeros_like(t)
     return (np.sin((1.0 - t) * angle) / np.sin(angle),

--- a/pytransform3d/rotations/_slerp.py
+++ b/pytransform3d/rotations/_slerp.py
@@ -69,10 +69,7 @@ def pick_closest_quaternion(quaternion, target_quaternion):
 
     .. warning::
         There are always two quaternions that represent the exact same
-        orientation: q and -q. The problem is that a DMP that moves from q to q
-        does not move at all, while a DMP that moves from q to -q moves a lot.
-        We have to make sure that start_y always contains the quaternion
-        representation that is closest to the previous start_y!
+        orientation: q and -q.
 
     Parameters
     ----------

--- a/pytransform3d/rotations/_slerp.py
+++ b/pytransform3d/rotations/_slerp.py
@@ -115,7 +115,7 @@ def _pick_closest_quaternion(quaternion, target_quaternion):
     return quaternion
 
 
-def rotor_slerp(start, end, t):
+def rotor_slerp(start, end, t, shortest_path=False):
     """Spherical linear interpolation.
 
     Parameters
@@ -129,6 +129,10 @@ def rotor_slerp(start, end, t):
     t : float in [0, 1]
         Position between start and end
 
+    shortest_path : bool, optional (default: False)
+        Resolve sign ambiguity before interpolation to find the shortest path.
+        The end rotor will be picked to be close to the start rotor.
+
     Returns
     -------
     rotor : array, shape (4,)
@@ -136,7 +140,7 @@ def rotor_slerp(start, end, t):
     """
     start = check_rotor(start)
     end = check_rotor(end)
-    return quaternion_slerp(start, end, t)
+    return quaternion_slerp(start, end, t, shortest_path)
 
 
 def slerp_weights(angle, t):

--- a/pytransform3d/rotations/_slerp.py
+++ b/pytransform3d/rotations/_slerp.py
@@ -32,7 +32,7 @@ def axis_angle_slerp(start, end, t):
     return w1 * start + w2 * end
 
 
-def quaternion_slerp(start, end, t):
+def quaternion_slerp(start, end, t, shortest_path=False):
     """Spherical linear interpolation.
 
     Parameters
@@ -46,6 +46,9 @@ def quaternion_slerp(start, end, t):
     t : float in [0, 1]
         Position between start and goal
 
+    shortest_path : bool, optional (default: False)
+        Resolve sign ambiguity before interpolation to find shortest path.
+
     Returns
     -------
     q : array, shape (4,)
@@ -53,6 +56,8 @@ def quaternion_slerp(start, end, t):
     """
     start = check_quaternion(start)
     end = check_quaternion(end)
+    if shortest_path:
+        raise NotImplementedError()
     angle = angle_between_vectors(start, end)
     w1, w2 = slerp_weights(angle, t)
     return w1 * start + w2 * end

--- a/pytransform3d/rotations/_slerp.pyi
+++ b/pytransform3d/rotations/_slerp.pyi
@@ -7,7 +7,8 @@ def axis_angle_slerp(
 
 
 def quaternion_slerp(
-        start: npt.ArrayLike, end: npt.ArrayLike, t: float) -> np.ndarray: ...
+        start: npt.ArrayLike, end: npt.ArrayLike, t: float,
+        shortest_path : bool = ...) -> np.ndarray: ...
 
 
 def rotor_slerp(

--- a/pytransform3d/rotations/_slerp.pyi
+++ b/pytransform3d/rotations/_slerp.pyi
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.typing as npt
+from typing import Union
 
 
 def axis_angle_slerp(
@@ -11,8 +12,15 @@ def quaternion_slerp(
         shortest_path: bool = ...) -> np.ndarray: ...
 
 
+def pick_closest_quaternion(
+        quaternion: npt.ArrayLike,
+        target_quaternion: npt.ArrayLike) -> np.ndarray: ...
+
+
 def rotor_slerp(
         start: npt.ArrayLike, end: npt.ArrayLike, t: float) -> np.ndarray: ...
 
 
-def slerp_weights(angle: float, t: float) -> np.ndarray: ...
+def slerp_weights(
+        angle: float,
+        t: Union[float, npt.ArrayLike]) -> Union[float, np.ndarray]: ...

--- a/pytransform3d/rotations/_slerp.pyi
+++ b/pytransform3d/rotations/_slerp.pyi
@@ -8,7 +8,7 @@ def axis_angle_slerp(
 
 def quaternion_slerp(
         start: npt.ArrayLike, end: npt.ArrayLike, t: float,
-        shortest_path : bool = ...) -> np.ndarray: ...
+        shortest_path: bool = ...) -> np.ndarray: ...
 
 
 def rotor_slerp(

--- a/pytransform3d/rotations/_slerp.pyi
+++ b/pytransform3d/rotations/_slerp.pyi
@@ -18,7 +18,8 @@ def pick_closest_quaternion(
 
 
 def rotor_slerp(
-        start: npt.ArrayLike, end: npt.ArrayLike, t: float) -> np.ndarray: ...
+        start: npt.ArrayLike, end: npt.ArrayLike, t: float,
+        shortest_path: bool = ...) -> np.ndarray: ...
 
 
 def slerp_weights(

--- a/pytransform3d/test/test_batch_rotations.py
+++ b/pytransform3d/test/test_batch_rotations.py
@@ -354,7 +354,7 @@ def test_quaternion_slerp_batch_sign_ambiguity():
 
     q2 *= -1.0
     traj_q_opposing = pbr.quaternion_slerp_batch(
-        q1, q2, np.linspace(0, 1, n_steps), shortest_path=True)
+        q1, q2, np.linspace(0, 1, n_steps), shortest_path=False)
     path_length_opposing = np.sum(
         [pr.quaternion_dist(r, s)
          for r, s in zip(traj_q_opposing[:-1], traj_q_opposing[1:])])

--- a/pytransform3d/test/test_batch_rotations.py
+++ b/pytransform3d/test/test_batch_rotations.py
@@ -361,7 +361,6 @@ def test_quaternion_slerp_batch_sign_ambiguity():
 
     assert_greater(path_length_opposing, path_length)
 
-    q2 *= -1.0
     traj_q_opposing_corrected = pbr.quaternion_slerp_batch(
         q1, q2, np.linspace(0, 1, n_steps), shortest_path=True)
     path_length_opposing_corrected = np.sum(

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -1411,6 +1411,26 @@ def test_interpolate_same_quaternion():
     assert_array_almost_equal(traj[2], q)
 
 
+def test_interpolate_shortest_path_same_quaternion():
+    """Test interpolate along shortest path with same quaternion."""
+    random_state = np.random.RandomState(8353)
+    q = pr.random_quaternion(random_state)
+    q_interpolated = pr.quaternion_slerp(q, q, 0.5, shortest_path=True)
+    assert_array_almost_equal(q, q_interpolated)
+
+    q = np.array([0.0, 1.0, 0.0, 0.0])
+    q_interpolated = pr.quaternion_slerp(q, -q, 0.5, shortest_path=True)
+    assert_array_almost_equal(q, q_interpolated)
+
+    q = np.array([0.0, 0.0, 1.0, 0.0])
+    q_interpolated = pr.quaternion_slerp(q, -q, 0.5, shortest_path=True)
+    assert_array_almost_equal(q, q_interpolated)
+
+    q = np.array([0.0, 0.0, 0.0, 1.0])
+    q_interpolated = pr.quaternion_slerp(q, -q, 0.5, shortest_path=True)
+    assert_array_almost_equal(q, q_interpolated)
+
+
 def test_quaternion_conventions():
     """Test conversion of quaternion between wxyz and xyzw."""
     q_wxyz = np.array([1.0, 0.0, 0.0, 0.0])

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -1384,7 +1384,6 @@ def test_interpolate_quaternion_shortest_path():
 
     assert_greater(path_length_opposing, path_length)
 
-    q2 *= -1.0
     traj_q_opposing_corrected = [
         pr.quaternion_slerp(q1, q2, t, shortest_path=True)
         for t in np.linspace(0, 1, n_steps)]

--- a/pytransform3d/test/test_rotations.py
+++ b/pytransform3d/test/test_rotations.py
@@ -1928,3 +1928,11 @@ def test_plane_basis_from_normal():
         x, y = pr.plane_basis_from_normal(normal)
         R = np.column_stack((x, y, normal))
         pr.assert_rotation_matrix(R)
+
+
+def test_pick_closest_quaternion():
+    random_state = np.random.RandomState(483)
+    for _ in range(10):
+        q = pr.random_quaternion(random_state)
+        assert_array_almost_equal(pr.pick_closest_quaternion(q, q), q)
+        assert_array_almost_equal(pr.pick_closest_quaternion(-q, q), q)

--- a/pytransform3d/test/test_trajectories.py
+++ b/pytransform3d/test/test_trajectories.py
@@ -6,7 +6,7 @@ from pytransform3d.trajectories import (
     pqs_from_dual_quaternions, dual_quaternions_from_pqs,
     batch_concatenate_dual_quaternions, batch_dq_prod_vector,
     transforms_from_dual_quaternions, dual_quaternions_from_transforms,
-    concat_one_to_many, concat_many_to_one)
+    concat_one_to_many, concat_many_to_one, mirror_screw_axis_direction)
 from pytransform3d.rotations import (
     quaternion_from_matrix, assert_quaternion_equal, active_matrix_from_angle,
     random_quaternion)
@@ -14,7 +14,8 @@ from pytransform3d.transformations import (
     exponential_coordinates_from_transform, translate_transform,
     rotate_transform, random_transform, transform_from_pq,
     concatenate_dual_quaternions, dq_prod_vector,
-    assert_unit_dual_quaternion_equal, invert_transform, concat)
+    assert_unit_dual_quaternion_equal, invert_transform, concat,
+    transform_from_exponential_coordinates)
 from pytransform3d.batch_rotations import norm_vectors
 from numpy.testing import assert_array_almost_equal
 
@@ -282,3 +283,16 @@ def test_batch_conversions_dual_quaternions_transforms_3dims():
         assert_unit_dual_quaternion_equal(dq1, dq2)
     A2Bs2 = transforms_from_dual_quaternions(dqs2)
     assert_array_almost_equal(A2Bs, A2Bs2)
+
+
+def test_mirror_screw_axis():
+    pose = np.array([[0.10156069, -0.02886784,  0.99441042,  0.6753021],
+                     [-0.4892026, -0.87182166,  0.02465395, -0.2085889],
+                     [0.86623683, -0.48897203, -0.10266503,  0.30462221],
+                     [0.0,  0.0,  0.0,  1.0]])
+    exponential_coordinates = exponential_coordinates_from_transform(pose)
+    mirror_exponential_coordinates = mirror_screw_axis_direction(
+        exponential_coordinates.reshape(1, 6))[0]
+    pose2 = transform_from_exponential_coordinates(
+        mirror_exponential_coordinates)
+    assert_array_almost_equal(pose, pose2)

--- a/pytransform3d/test/test_transformations.py
+++ b/pytransform3d/test/test_transformations.py
@@ -852,6 +852,30 @@ def test_dual_quaternion_sclerp():
             interpolated_poses[t], sclerp_interpolated_poses_from_dqs[t])
 
 
+def test_dual_quaternion_sclerp_sign_ambiguity():
+    n_steps = 10
+    random_state = np.random.RandomState(2323)
+    T1 = random_transform(random_state)
+    dq1 = dual_quaternion_from_transform(T1)
+    dq2 = np.copy(dq1)
+
+    if np.sign(dq1[0]) != np.sign(dq2[0]):
+        dq2 *= -1.0
+    traj_q = [dual_quaternion_sclerp(dq1, dq2, t)
+              for t in np.linspace(0, 1, n_steps)]
+    path_length = np.sum([np.linalg.norm(r - s)
+                          for r, s in zip(traj_q[:-1], traj_q[1:])])
+
+    dq2 *= -1.0
+    traj_q_opposing = [dual_quaternion_sclerp(dq1, dq2, t)
+                       for t in np.linspace(0, 1, n_steps)]
+    path_length_opposing = np.sum(
+        [np.linalg.norm(r - s)
+         for r, s in zip(traj_q_opposing[:-1], traj_q_opposing[1:])])
+
+    assert_equal(path_length_opposing, path_length)
+
+
 def test_exponential_coordinates_from_almost_identity_transform():
     A2B = np.array([
         [0.9999999999999999, -1.5883146449068575e-16, 4.8699079321578667e-17,

--- a/pytransform3d/trajectories.pyi
+++ b/pytransform3d/trajectories.pyi
@@ -57,3 +57,6 @@ def plot_trajectory(
         normalize_quaternions: bool = ..., show_direction: bool = ...,
         n_frames: int = ..., s: float = ..., ax_s: float = ...,
         **kwargs) -> Axes3D: ...
+
+
+def mirror_screw_axis_direction(Sthetas: npt.ArrayLike) -> np.ndarray: ...


### PR DESCRIPTION
Fixes #122 

- Add `pytransform3d.rotations.pick_closest_quaternion`
- Add `pytransform3d.batch_rotations.smooth_quaternion_trajectory`
- Add `pytransform3d.trajectories.mirror_screw_axis_direction`
- Add optional parameter `shortest_path` to indicate that sign ambiguity should be resolved in `quaternion_slerp_batch`, `quaternion_slerp`, and `rotor_slerp`
- Document `slerp_weights` and correct type hints

TODO
- [x] quaternion slerp
- [x] dual quaternion slerp -> seems to be not an issue
- [x] batch quaternion slerp
- [x] trajectory correction for quaternions
- [x] trajectory correction for exponential coordinates